### PR TITLE
use github rather than custom otherLinks

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
+    <script defer src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
     <script class="remove">
       var respecConfig = {
       // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
@@ -22,22 +22,11 @@
 
       // name of the WG
       group: "wg/timed-text",
+      github: "w3c/dapt",
 
       scheme: "https",
 
       otherLinks: [{
-      key: 'Repository',
-      data: [{
-          value: 'We are on GitHub',
-          href: 'https://github.com/w3c/dapt/'
-        }, {
-          value: 'File a bug',
-          href: 'https://github.com/w3c/dapt/issues'
-        }, {
-          value: 'Commit history',
-          href: 'https://github.com/w3c/dapt/commits/main/index.html'
-        }]
-      },{
         key: 'Mailing list',
         data: [{
           value: 'public-tt@w3.org',

--- a/index.html
+++ b/index.html
@@ -23,16 +23,7 @@
       // name of the WG
       group: "wg/timed-text",
       github: "w3c/dapt",
-
-      scheme: "https",
-
-      otherLinks: [{
-        key: 'Mailing list',
-        data: [{
-          value: 'public-tt@w3.org',
-          href: 'https://lists.w3.org/Archives/Public/public-tt/'
-        }]
-      }],
+      wgPublicList: "public-tt",
 
       };
     </script>


### PR DESCRIPTION
Use respec generated feedback links, rather than using otherLinks.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/dapt/pull/10.html" title="Last updated on Jun 10, 2022, 8:22 AM UTC (f51bfae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/10/1816c32...himorin:f51bfae.html" title="Last updated on Jun 10, 2022, 8:22 AM UTC (f51bfae)">Diff</a>