### PR TITLE
defining Script Type value for Audio Descriptions

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,6 +141,7 @@ table.coldividers td + td { border-left:1px solid gray; }
                   </li>
                   <li><dfn>Pre-recording Dub Script</dfn>: (Dubbing Script) Result of the adaptation of a <a>Translated Dialogue List</a> for better lip-sync. It may also contain <a>Events</a> from the <a>Original Language Dialogue List</a> for context, to assist further processing.</li>
                   <li><dfn>As-recorded Dub Script</dfn>: (Dubbing Script) Represents a transcription of the output of the dubbing workflow. It may also contain <a>Events</a> from the <a>Original Language Dialogue List</a> for context and quality verifications.</li>
+                  <li><dfn>Audio Description Script</dfn>: (Audio Description Script) Script describing as recorded text script, times, optional links to audio and mixing instructions.</li>
                 </ul>
               </p>
               <p>A <a>DAPT script</a> MUST specify a <a>Script Type</a>.</p>
@@ -324,6 +325,7 @@ table.coldividers td + td { border-left:1px solid gray; }
                     <li><code>x-DUBBING_TRANSLATED_DIALOGUE_LIST</code> for <a>Translated Dialogue List</a></li>
                     <li><code>x-DUBBING_PRE_RECORDING</code> for <a>Pre-recording Dub Script</a></li>
                     <li><code>x-DUBBING_AS_RECORDED</code> for <a>As-recorded Dub Script</a></li>
+                    <li><code>x-AUDIO_DESCRIPTION</code> for <a>Audio Description Script</a></li>
                   </ul>
                   <p class="issue" data-number="24"></p>
                   <p class="issue" data-number="32"></p>

--- a/index.html
+++ b/index.html
@@ -145,7 +145,6 @@ table.coldividers td + td { border-left:1px solid gray; }
                 </ul>
               </p>
               <p>A <a>DAPT script</a> MUST specify a <a>Script Type</a>.</p>
-              <p class="issue" data-number="11"></p>
               <p class="issue" data-number="13"></p>
           </section>
           <section>


### PR DESCRIPTION
Closes #11


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/pull/41.html" title="Last updated on Sep 14, 2022, 5:25 PM UTC (6d5d3a5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/41/0a62b59...6d5d3a5.html" title="Last updated on Sep 14, 2022, 5:25 PM UTC (6d5d3a5)">Diff</a>