### PR TITLE
Clarify character styling and other styling requirements

### DIFF
--- a/index.html
+++ b/index.html
@@ -478,6 +478,7 @@ table.coldividers td + td { border-left:1px solid gray; }
             <p>Character Styles are applied to <a>Script Events</a> and <a>Text</a> by using the <code>style</code> attribute to specify the set of applicable styles.
               Presentation Processors MUST NOT apply character styles to text if they are not specified using the <code>style</code> attribute.
             </p>
+            <p class="issue" data-number="44"></p>
             <aside class="note">Given a document that specifies a <code>&lt;style&gt;</code> element with a <code>ttm:agent</code> attribute,
             and a <a>Script Event</a> with the same <code>ttm:agent</code> attribute value,
             but that does not reference (directly or by inheritance) that style using a <code>style</code> attribute,

--- a/index.html
+++ b/index.html
@@ -404,7 +404,7 @@ table.coldividers td + td { border-left:1px solid gray; }
             <li><dfn data-lt="Character Identifier">Identifier</dfn> which is a unique identifier to indicate when a <a>Character</a> participates in a <a>Script Event</a></li>
             <li><dfn data-lt="Character Name">Name</dfn> which is the name of the <a>Character</a> in the programme</li>
             <li>an optional <dfn data-lt="Character Talent Name">Talent Name</dfn>, which is the name of the actor speaking dialogue for this <a>Character</a></li>
-            <li>one or more optional <dfn data-lt="Character Style">Character Style</dfn> objects
+            <li>zero or more <dfn data-lt="Character Style">Character Style</dfn> objects
               which can be applied to control the visual appearance of <a>Script Events</a> spoken by the <a>Character</a>,
               for example during recording by an actor or when transforming the script into subtitles.</li>
           </ul>
@@ -457,7 +457,7 @@ table.coldividers td + td { border-left:1px solid gray; }
 ...
         </pre>
 
-            <li>If the <a>Character</a> has one or more <a>Character Styles</a>, the following TTML constraints apply:
+            <li>A <a>Character Style</a> is represented in TTML with the following structure and constraints:
               <ul>
                 <li>Each <a>Character Style</a> is represented by one or more <code>&lt;style&gt;</code> element children of the <code>&lt;styling&gt;</code> element.</li>
                 <li>Each such <code>&lt;style&gt;</code> element is associated with the <a>Character</a> by having a <code>ttm:agent</code> attribute
@@ -473,7 +473,8 @@ table.coldividers td + td { border-left:1px solid gray; }
 
             <p class="note">Any style attribute defined in [[TTML2]] or [[ttml-imsc1.2]]
               (or other profiles using non-W3C namespaces) can be present on the <code>&lt;style&gt;</code> element.</p>
-            <p>A <code>&lt;style&gt;</code> element MAY omit the <code>ttm:agent</code> attribute.</p>
+            <p>A <code>&lt;style&gt;</code> element MAY omit the <code>ttm:agent</code> attribute if it is not associated with a <a>Character</a>.
+              Such styles MAY be applied in the same way as any other style, via a reference in the <code>style</code> attribute.</p>
             <p>Character Styles are applied to <a>Script Events</a> and <a>Text</a> by using the <code>style</code> attribute to specify the set of applicable styles.
               Presentation Processors MUST NOT apply character styles to text if they are not specified using the <code>style</code> attribute.
             </p>

--- a/index.html
+++ b/index.html
@@ -481,7 +481,7 @@ table.coldividers td + td { border-left:1px solid gray; }
             <aside class="note">Given a document that specifies a <code>&lt;style&gt;</code> element with a <code>ttm:agent</code> attribute,
             and a <a>Script Event</a> with the same <code>ttm:agent</code> attribute value,
             but that does not reference (directly or by inheritance) that style using a <code>style</code> attribute,
-            a Presentation Processor would not be conformant be if it applied that style anyway, solely on the basis of the <code>ttm:agent</code>
+            a Presentation Processor would not be conformant if it applied that style anyway, solely on the basis of the <code>ttm:agent</code>
             being the same.</aside>
 
         <pre class="example">

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>Dubbing and Audio description Profiles of TTML2</title>
     <script defer src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
     <script class="remove">
       var respecConfig = {
@@ -109,10 +110,10 @@ table.coldividers td + td { border-left:1px solid gray; }
       <p>This specification defines a text-based profile of the Timed Text Markup Language version 2.0 [[TTML2]]
         intended to support dubbing and audio description workflows worldwide,
         to meet the requirements defined in [[[?DAPT-REQS]]], and to permit usage of visual presentation
-        features within [[TTML2]] and its profiles, for example those in [[ttml-imsc1.2]].
+        features within [[TTML2]] and its profiles, for example those in [[ttml-imsc1.2]].</p>
     </section>
 
-    <section class='informative' id="introduction">
+    <section class="informative" id="introduction">
       <h2>Introduction</h2>
       <p>Creating a dub is a complex, multi-step process that involves:
         <ul>
@@ -171,7 +172,7 @@ table.coldividers td + td { border-left:1px solid gray; }
         <p>After creating audio recordings, if not using text to speech, instructions for playback
           mixing can be inserted. For example, The gain of "received" audio can be changed before mixing in
           the audio played from inside the <code>span</code>, smoothly
-          animating the value on the way in and returning it on the way out:</p>
+          animating the value on the way in and returning it on the way out:
         </p>
         <pre class="example"
           data-include="examples/intro-script-with-gain.xml"
@@ -403,7 +404,9 @@ table.coldividers td + td { border-left:1px solid gray; }
             <li><dfn data-lt="Character Identifier">Identifier</dfn> which is a unique identifier to indicate when a <a>Character</a> participates in a <a>Script Event</a></li>
             <li><dfn data-lt="Character Name">Name</dfn> which is the name of the <a>Character</a> in the programme</li>
             <li>an optional <dfn data-lt="Character Talent Name">Talent Name</dfn>, which is the name of the actor speaking dialogue for this <a>Character</a></li>
-            <li>an optional <dfn data-lt="Character Style">Style</dfn> object which can be used to control the style when displaying the <a>Script Event</a> for example during recording by an actor</li>
+            <li>one or more optional <dfn data-lt="Character Style">Character Style</dfn> objects
+              which can be applied to control the visual appearance of <a>Script Events</a> spoken by the <a>Character</a>,
+              for example during recording by an actor or when transforming the script into subtitles.</li>
           </ul>
         </p>
         <p>A <a>Character</a> is represented in TTML with the following structure and constraints:
@@ -454,15 +457,31 @@ table.coldividers td + td { border-left:1px solid gray; }
 ...
         </pre>
 
-            <li>If the <a>Character</a> has a <a>Style</a>, the following TTML constraints apply:
+            <li>If the <a>Character</a> has one or more <a>Character Styles</a>, the following TTML constraints apply:
               <ul>
-                <li>There MAY be a <code>style</code> element in the <code>styling</code> element providing the styles applicable to <a>Script Events</a> from this <a>Character</a>.
-                  The <code>xml:id</code> MUST be present.
-                  Any style attribute permitted in [[ttml-imsc1.2]] may be present.
-                  A <code>ttm:agent</code> attribute MAY be present to link the <code>ttm:agent</code> element representing the <a>Character</a>.
-                </li>
+                <li>Each <a>Character Style</a> is represented by one or more <code>&lt;style&gt;</code> element children of the <code>&lt;styling&gt;</code> element.</li>
+                <li>Each such <code>&lt;style&gt;</code> element is associated with the <a>Character</a> by having a <code>ttm:agent</code> attribute
+                  whose value is the <code>xml:id</code> of the <code>&lt;ttm:agent&gt;</code> element representing the <a>Character</a>.</li>
+                <li>A <a>Script Event</a> MAY apply <a>Character Styles</a> by including the <code>xml:id</code> of each style
+                  in the <code>style</code> attribute of the <code>&lt;div&gt;</code> element that defines that Script Event.</li>
+                <li>A <a>Text</a> object MAY apply <a>Character Styles</a> by including  the <code>xml:id</code> of each style
+                  in the <code>style</code> attribute of the <code>&lt;p&gt;</code> element that defines that Text object.</li>
+                <li>A <a>Script Event</a> SHOULD NOT apply a <a>Character Style</a> for a <a>Character</a> that is not associated with that Script Event.</li>
+                <li>A <a>Text</a> object SHOULD NOT apply a <a>Character Style</a> for a <a>Character</a> that is not associated with that Text object's Script Event.</li>
               </ul>
             </li>
+
+            <p class="note">Any style attribute defined in [[TTML2]] or [[ttml-imsc1.2]]
+              (or other profiles using non-W3C namespaces) can be present on the <code>&lt;style&gt;</code> element.</p>
+            <p>A <code>&lt;style&gt;</code> element MAY omit the <code>ttm:agent</code> attribute.</p>
+            <p>Character Styles are applied to <a>Script Events</a> and <a>Text</a> by using the <code>style</code> attribute to specify the set of applicable styles.
+              Presentation Processors MUST NOT apply character styles to text if they are not specified using the <code>style</code> attribute.
+            </p>
+            <aside class="note">Given a document that specifies a <code>&lt;style&gt;</code> element with a <code>ttm:agent</code> attribute,
+            and a <a>Script Event</a> with the same <code>ttm:agent</code> attribute value,
+            but that does not reference (directly or by inheritance) that style using a <code>style</code> attribute,
+            a Presentation Processor would not be conformant be if it applied that style anyway, solely on the basis of the <code>ttm:agent</code>
+            being the same.</aside>
 
         <pre class="example">
 ...
@@ -472,12 +491,18 @@ table.coldividers td + td { border-left:1px solid gray; }
          tts:color=&quot;#FFFFFF&quot; tts:backgroundColor=&quot;#8F42AD&quot;/&gt;         
 &lt;/styling&gt;     
 ...
+  &lt;div xml:id="event_6" ttm:agent="character_3" style="style_a" ... &gt;
+  &lt;-- Script event contents here, in Character 3's style --&gt;
+  &lt;/div&gt;
+
+  &lt;div xml:id="event_7" ttm:agent="character_3" style="some_other_style" ... &gt;
+  &lt;-- Script event contents here, not in Character 3's style --&gt;
+  &lt;/div&gt;
         </pre>
 
           </ul>
         </p>
 
-        <p class="issue" data-number="29"></p>
         <p class="issue" data-number="15"></p>
       </section>
 
@@ -523,7 +548,7 @@ table.coldividers td + td { border-left:1px solid gray; }
           </pre>
               <li>It MUST contain one <code>p</code> element representing the <a>Main Text</a>.</li>
               <li>It MAY contain another <code>p</code> element representing the <a>Contextual Text</a></li>
-              <li>The <code>style</code> attribute MAY be present. If present, it MAY contain a reference to the <code>style</code> defining the <a>Character Style</a>. Additional style references or inline styles MAY be used.</li>
+              <li>The <code>style</code> attribute MAY be present. If present, it MAY contain a reference to the <code>&lt;style&gt;</code> defining the <a>Character Style</a>. Additional style references or inline styles MAY be used.</li>
               <li>It MAY contain a <code>metadata</code> element representing the <a>On Screen</a> property.</li>
             </ul>
           </ul>
@@ -532,16 +557,30 @@ table.coldividers td + td { border-left:1px solid gray; }
 
         <section>
           <h4>Text</h4>
-          <p>The <dfn>Text</dfn> object contains text content in a single language, and may be styled and associated with a <a>Character</a>. The <a>Main Text</a> and <a>Contextual Text</a> objects of <a>Script Events</a> are <a>Text</a> objects.</p>
+          <p>The <dfn>Text</dfn> object contains text content in a single language, and may be styled and associated with a <a>Character</a>.
+            The <a>Main Text</a> and <a>Contextual Text</a> objects of <a>Script Events</a> are <a>Text</a> objects.</p>
           <p class="issue" data-number="15"></p>
-          <p>A <a>Text</a> object is represented with a <code>p</code> element with the following constraints:
+          <p>A <a>Text</a> object is represented with a <code>p</code> element with the following constraints:</p>
             <ul>
-              <li>The text content of the <code>p</code> is the <a>Text</a> of the <a>Script Event</a>. It MAY also use TTML markup to represent styles.
-                <div class="note">The text content of the paragraph may contain TTML elements such as <code>span</code> or TTML attributes such as <code>tts:ruby</code> used to alter the layout or styling of each paragraph</div>
+              <li>The text content of the <code>&lt;p&gt;</code> is the <a>Text</a> of the <a>Script Event</a>.
+                <div class="note">The text content of the paragraph can be structured using TTML elements such as
+                  <code>&lt;br&gt;</code> or <code>&lt;span&gt;</code>
+                  which can include TTML attributes such as <code>tts:ruby</code> used to alter the layout or styling of
+                  sections of text within each paragraph.
+                  Similarly metadata can be added using attributes or <code>&lt;metadata&gt;</code> elements.</div>
+                <p class="ednote">Need to specify that <code>&lt;audio&gt;</code> elements are permitted too, for AD mixing.</p>
               </li>
+              <li>The <code>style</code> attribute MAY be present.
+                If present, it MAY contain a reference to the <code>&lt;style&gt;</code> that defines the relevant <a>Character Style</a>.
+                Additional style references or inline styles MAY be used as defined in [[TTML2]],
+                and MAY be applied to sub-sections of the text defined by <code>&lt;span&gt;</code> elements.</li>
               <li>The <code>p</code> element MUST have an <code>xml:lang</code> attribute corresponding to the language of the <a>Text</a> object.
-              <div class="note">Within a <code>div</code> representing a <a>Script Event</a>, the order of <code>p</code> is one relevant. The <code>xml:lang</code> value can be used to determine which paragraph corresponds to the <a>Main Text</a> and which one corresponds to the <a>Contextual Text</a>. Text content in a language that does not match the <a>Primary Language</a> of the <a>DAPT Script</a> are <a>Contextual Text</a>.</div>
+              <div class="note">Within a <code>&lt;div&gt;</code> representing a <a>Script Event</a>
+                 the order of <code>&lt;p&gt;</code> children is significant.
+                 The <code>xml:lang</code> value can be used to determine which paragraph corresponds to the <a>Main Text</a> and which one corresponds to the <a>Contextual Text</a>.
+                 Text content in a language that does not match the <a>Primary Language</a> of the <a>DAPT Script</a> are <a>Contextual Text</a>.</div>
               </li>
+            </ul>
           <pre class="example">
 &lt;div xml:id=&quot;event_3&quot;
      begin=&quot;9663f&quot; end=&quot;9682f&quot; 
@@ -1040,7 +1079,7 @@ daptm:onScreen
               <td></td>
             </tr>
             <tr>
-              <td id="profile-constraints"><code>#profile</code></td>
+              <td><code>#profile</code></td>
               <td>permitted</td>
               <td>
                 See <a href="#profile-signaling-section" class="sec-ref"></a>.
@@ -1232,7 +1271,7 @@ daptm:onScreen
       </section>
     </section>
 
-  <section id="ttml-format">
+  <section id="ttml-format-to-remove">
       <h4>TTML Format</h4>
       <p>This section defines the TTML format based on the data model defined in [[[#data-model]]].</p>
       <p class="issue" data-number="25"></p>


### PR DESCRIPTION
Closes #29 and #60.

* Drive-by fix of a few linting/HTML syntax errors including removing two duplicate id attribute values.
* Define Character Style
* Specify that Character Styles are style elements with ttm:agent attributes matching the xml:id of the ttm:agent element for the Character
* Character Styles can be applied to Script Events and Text objects using the style attribute
* Presentation processors must not associate them with character styles via any other mechanism, e.g. matching the ttm:agent attributes only. Note and example also included.
* Permit other non-Character Style styling including inline
* Tweak text that permits <p> elements to contain mixed content
* Tweak note about the order of <p> elements mattering, for grammar.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/pull/76.html" title="Last updated on Dec 1, 2022, 10:49 AM UTC (185e0f6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/76/53c4166...185e0f6.html" title="Last updated on Dec 1, 2022, 10:49 AM UTC (185e0f6)">Diff</a>