### PR TITLE
Specify entity reference requirements

### DIFF
--- a/index.html
+++ b/index.html
@@ -789,10 +789,20 @@ daptm:onScreen
             <li><em>entity references</em> other than to <em>predefined entities</em>.</li>
           </ul>
     
-          <p class="note">The resulting [[xml]] document can contain
+          <div class="note">
+            <p>The resulting [[xml]] document can contain
             <dfn data-cite="xml#dt-charref">character references</dfn>,
             and <dfn data-cite="xml#dt-entref">entity referencess</dfn> to
             <dfn data-cite="xml#sec-predefined-ent">predefined entities</dfn>.</p>
+            <p>The predefined entities are (including the leading ampersand and trailing semicolon):</p>
+            <ul>
+              <li><code>&amp;amp;</code> for an ampersand &amp;</li>
+              <li><code>&amp;apos;</code> for an apostrophe &apos;</li>
+              <li><code>&amp;gt;</code> for a greater than sign &gt;</li>
+              <li><code>&amp;lt;</code> for a less than sign &lt;</li>
+              <li><code>&amp;quot;</code> for a quote symbol &quot;</li>
+            </ul>
+          </div>
       </section>
       <section id="foreign-elements-and-attributes">
         <h3>Foreign Element and Attributes</h3>

--- a/index.html
+++ b/index.html
@@ -778,7 +778,7 @@ daptm:onScreen
       <h2>Constraints</h2>
       <section id="Document Encoding">
         <h3>Document Encoding</h3>
-        <p>A <a>Document Instance</a> SHALL be concretely encoded as a well-formed XML 1.0 [[!xml]] document using the UTF-8
+        <p>A <a>Document Instance</a> MUST be concretely encoded as a well-formed XML 1.0 [[!xml]] document using the UTF-8
           character encoding as specified in [[UNICODE]].</p>
     
           <p>The resulting [[!xml]] document MUST NOT contain any of the following physical structures:</p>

--- a/index.html
+++ b/index.html
@@ -778,8 +778,8 @@ daptm:onScreen
       <h2>Constraints</h2>
       <section id="Document Encoding">
         <h3>Document Encoding</h3>
-        <p>A <a>Document Instance</a> MUST be concretely encoded as a well-formed XML 1.0 [[!xml]] document using the UTF-8
-          character encoding as specified in [[UNICODE]].</p>
+        <p>A <a>Document Instance</a> MUST be serialised as a well-formed XML 1.0 [[!xml]] document
+          encoded using the UTF-8 character encoding as specified in [[UNICODE]].</p>
     
           <p>The resulting [[!xml]] document MUST NOT contain any of the following physical structures:</p>
     
@@ -803,6 +803,9 @@ daptm:onScreen
               <li><code>&amp;quot;</code> for a quote symbol &quot;</li>
             </ul>
           </div>
+
+          <p class="note">A <a>Document Instance</a> can also be used as an in-memory model
+            for processing, in which case the serialisation requirements do not apply.</p>
       </section>
       <section id="foreign-elements-and-attributes">
         <h3>Foreign Element and Attributes</h3>

--- a/index.html
+++ b/index.html
@@ -778,9 +778,19 @@ daptm:onScreen
       <h2>Constraints</h2>
       <section id="Document Encoding">
         <h3>Document Encoding</h3>
-        <p>
-          A Document Instance MUST use UTF-8 character encoding as specified in [[UNICODE]].
-        </p>
+        <p>A <a>Document Instance</a> SHALL be concretely encoded as a well-formed XML 1.0 [[!xml]] document using the UTF-8
+          character encoding as specified in [[UNICODE]].</p>
+    
+          <p>The resulting [[!xml]] document MUST NOT contain any of the following physical structures:</p>
+    
+          <ul>
+            <li><em>entity declarations</em>; and</li>
+    
+            <li><em>entity references</em> other than to <em>predefined entities</em>.</li>
+          </ul>
+    
+          <p class="note">The resulting [[xml]] document can contain <em>character references</em>, and <em>entity references</em> to
+          <em>predefined entities</em>.</p>
       </section>
       <section id="foreign-elements-and-attributes">
         <h3>Foreign Element and Attributes</h3>

--- a/index.html
+++ b/index.html
@@ -789,8 +789,10 @@ daptm:onScreen
             <li><em>entity references</em> other than to <em>predefined entities</em>.</li>
           </ul>
     
-          <p class="note">The resulting [[xml]] document can contain <em>character references</em>, and <em>entity references</em> to
-          <em>predefined entities</em>.</p>
+          <p class="note">The resulting [[xml]] document can contain
+            <dfn data-cite="xml#dt-charref">character references</dfn>,
+            and <dfn data-cite="xml#dt-entref">entity referencess</dfn> to
+            <dfn data-cite="xml#sec-predefined-ent">predefined entities</dfn>.</p>
       </section>
       <section id="foreign-elements-and-attributes">
         <h3>Foreign Element and Attributes</h3>


### PR DESCRIPTION
Resolves #51.

Takes the existing text from IMSC 1.2, changes the SHOULD NOT to a MUST NOT and removes the note about future specification intention to make into a MUST NOT.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/pull/79.html" title="Last updated on Dec 2, 2022, 5:02 PM UTC (dfcc9c7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/79/640e525...dfcc9c7.html" title="Last updated on Dec 2, 2022, 5:02 PM UTC (dfcc9c7)">Diff</a>