### PR TITLE
remove redundant sentence in conventions

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,10 +220,6 @@ table.coldividers td + td { border-left:1px solid gray; }
         Sections 6.2 and 8.2 of [[TTML2]] specify conventions used when specifying the syntax of attribute values.
       </p>
       <p>
-        All content of this specification that is not explicitly marked as non-normative is considered to be normative.
-        If a section or appendix header contains the expression "non-normative", then the entirety of the section or appendix is considered non-normative.
-      </p>
-      <p>
         This specification uses <dfn data-cite="ttml2#terms-feature">Feature</dfn> designations as defined in Appendices E at [[TTML2]]:
         when making reference to content conformance, these designations refer to the syntactic expression or the semantic capability associated with each designated <a>Feature</a>; and
         when making reference to <dfn data-cite="ttml2#terms-processor">Processor</dfn> conformance, these designations refer to processing requirements associated with each designated <a>Feature</a>.


### PR DESCRIPTION
close #93


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/pull/94.html" title="Last updated on Dec 8, 2022, 6:21 PM UTC (047fc42)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/94/8c0626b...047fc42.html" title="Last updated on Dec 8, 2022, 6:21 PM UTC (047fc42)">Diff</a>