### PR TITLE
Rename DUBBING_ORIGINAL_DIALOGUE_LIST and DUBBING_TRANSLATED_DIALOGUE_LIST

### DIFF
--- a/examples/intro-original-language-with-dub-language.xml
+++ b/examples/intro-original-language-with-dub-language.xml
@@ -3,7 +3,7 @@
     xmlns:daptm="http://www.w3.org/ns/ttml/profile/dapt#metadata"
     xml:lang="en"
     ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/dapt"
-    daptm:scriptType="DUBBING_TRANSLATED_DIALOGUE_LIST">
+    daptm:scriptType="TRANSLATED_TRANSCRIPT">
   <head>
     <metadata>
       <ttm:agent type="character" xml:id="character_1">

--- a/examples/intro-original-language.xml
+++ b/examples/intro-original-language.xml
@@ -3,7 +3,7 @@
     xmlns:daptm="http://www.w3.org/ns/ttml/profile/dapt#metadata"
     xml:lang="fr" 
     ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/dapt"
-    daptm:scriptType="DUBBING_ORIGINAL_DIALOGUE_LIST">
+    daptm:scriptType="ORIGINAL_TRANSCRIPT">
   <head>
     <metadata>
       <ttm:agent type="character" xml:id="character_1">

--- a/examples/intro-top-level.xml
+++ b/examples/intro-top-level.xml
@@ -3,7 +3,7 @@
     xmlns:daptm="http://www.w3.org/ns/ttml/profile/dapt#metadata"
     xml:lang="en" 
     ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/dapt"
-    daptm:scriptType="DUBBING_ORIGINAL_DIALOGUE_LIST">
+    daptm:scriptType="ORIGINAL_TRANSCRIPT">
   <head>
     <metadata>
       <!-- Additional metadata may be placed here -->

--- a/index.html
+++ b/index.html
@@ -263,13 +263,26 @@ table.coldividers td + td { border-left:1px solid gray; }
           <p>A <a>DAPT Script</a> is represented as a TTML document with the structure and constraints also defined in the following sections.</p>
           <section>
             <h4>Script Type</h4>
-            <p>The <dfn>Script Type</dfn> property is a mandatory property of a <a>DAPT Script</a> which describes the type of documents used in Dubbing and Audio Description workflows, among the following: <a>Original Language Dialogue List</a>, <a>Translated Dialogue List</a>, <a>Pre-recording Dub Script</a>, <a>As-recorded Dub Script</a>, and <a>Audio Description Script</a>. <a>Original Language Dialogue List</a>, <a>Translated Dialogue List</a>, <a>Pre-recording Dub Script</a>, <a>As-recorded Dub Script</a> are referred to as <dfn>Dubbing Scripts</dfn>.</p>
+            <p>The <dfn>Script Type</dfn> property is a mandatory property of a <a>DAPT Script</a>
+              which describes the type of documents used in Dubbing and Audio Description workflows,
+              among the following:
+              <a>Original Language Transcript</a>,
+              <a>Translated Transcript</a>,
+              <a>Pre-recording Dub Script</a>,
+              <a>As-recorded Dub Script</a>, and
+              <a>Audio Description Script</a>.</p>
+            <p>
+              <a>Original Language Transcript</a>,
+              <a>Translated Transcript</a>,
+              <a>Pre-recording Dub Script</a>, and
+              <a>As-recorded Dub Script</a>
+              are referred to as <dfn>Dubbing Scripts</dfn>.</p>
             <p>To represent this property, the following TTML attribute MUST be present on the <code>tt</code> element:</p>
             <div class="exampleInner">
               <pre class="nohighlight">
   daptm:scriptType
-    : "DUBBING_ORIGINAL_DIALOGUE_LIST"
-    | "DUBBING_TRANSLATED_DIALOGUE_LIST"
+    : "ORIGINAL_TRANSCRIPT"
+    | "TRANSLATED_TRANSCRIPT"
     | "DUBBING_PRE_RECORDING"
     | "DUBBING_AS_RECORDED"
     | "AUDIO_DESCRIPTION"
@@ -279,22 +292,22 @@ table.coldividers td + td { border-left:1px solid gray; }
             <p>The definitions of the types of documents and the corresponding <code>daptm:scriptType</code> values are:
               <ul>
                 <li>
-                  <dfn>Original Language Dialogue List</dfn>:
-                  <p>When the <code>daptm:scriptType</code> value is <code>DUBBING_ORIGINAL_DIALOGUE_LIST</code>,
+                  <dfn>Original Language Transcript</dfn>:
+                  <p>When the <code>daptm:scriptType</code> value is <code>ORIGINAL_TRANSCRIPT</code>,
                   the document is a literal transcription of the dialogue and on-screen text in their original spoken/written language(s).</p>
                   <p><a>Script Events</a> in this type of script SHOULD contain <a>Text</a> objects whose
                     <a>Text Language Source</a> is set to <a>Original</a>
                     and SHOULD NOT contain <a>Text</a> objects whose
                     <a>Text Language Source</a> is set to <a>Translation</a>.</p>
                 <aside class="example">If a programme contains dialogue in English and Hebrew,
-                  the <a>Original Language Dialogue List</a> will contain some <a>Script Events</a> in English and some in Hebrew,
+                  the <a>Original Language Transcript</a> will contain some <a>Script Events</a> in English and some in Hebrew,
                   all marked as <a>Original</a> <a>Text Language Source</a>.
                   None of the <a>Script Events</a> is marked as <a>Translation</a>.</aside>
                 </li>
                 <li>
-                  <dfn>Translated Dialogue List</dfn>:
-                  <p>When the <code>daptm:scriptType</code> value is <code>DUBBING_TRANSLATED_DIALOGUE_LIST</code>,
-                  the document represents a translation of the <a>Original Language Dialogue List</a> in a common language.</p>
+                  <dfn>Translated Transcript</dfn>:
+                  <p>When the <code>daptm:scriptType</code> value is <code>TRANSLATED_TRANSCRIPT</code>,
+                  the document represents a translation of the <a>Original Language Transcript</a> in a common language.</p>
                   <p>It can be adapted to produce a <a>Pre-Recording Dub Script</a>,
                   and/or used as the basis for producing translation subtitles,
                   or used as the basis for a further translation into the <a>Target Recording Language</a>.</p> 
@@ -309,21 +322,21 @@ table.coldividers td + td { border-left:1px solid gray; }
                   for example used as intermediate (&quot;pivot&quot;) translations,
                   or as additional context to assist in the adaptation process.</aside>
                 <aside class="example">If a programme contains dialogue in English and Hebrew,
-                  the French <a>Translated Dialogue List</a> will contain at least the translation in French of all <a>Script Events</a>.
+                  the French <a>Translated Transcript</a> will contain at least the translation in French of all <a>Script Events</a>.
                   It may still retain text content in Hebrew and English to assist further processing.</aside>
                 </li>
                 <li>
                   <dfn>Pre-recording Dub Script</dfn>:
                   <p>When the <code>daptm:scriptType</code> value is <code>DUBBING_PRE_RECORDING</code>,
-                  the document represents the result of the adaptation of a <a>Translated Dialogue List</a> for dubbing,
+                  the document represents the result of the adaptation of a <a>Translated Transcript</a> for dubbing,
                   e.g. for better lip-sync.</p>
                   <p><a>Script Events</a> in this type of script SHOULD contain <a>Translation</a> <a>Text</a> objects
                     in the <a>Target Recording Language</a>
-                    and MAY also contain <a>Original</a> <a>Text</a> objects from the <a>Original Language Dialogue List</a>
+                    and MAY also contain <a>Original</a> <a>Text</a> objects from the <a>Original Language Transcript</a>
                     or <a>Translation</a> <a>Text</a> objects in other languages for context,
                     to assist further processing.</p>
                   <aside class="note">The <a>Script Type</a> of a <a>DAPT Script</a> cannot necessarily be detected by inspecting the text content of the document.
-                  For example, the adaptation of a <a>Translated Dialogue List</a> into a <a>Pre-recording Dub Script</a>
+                  For example, the adaptation of a <a>Translated Transcript</a> into a <a>Pre-recording Dub Script</a>
                   can consist in replacing some words in the text content of a <a>Script Event</a> without altering the rest of the document.
                   In either case, <a>Text</a> objects that are translations have <a>Text Language Source</a> properties set to <a>Translation</a>.</aside>
                 </li>
@@ -333,7 +346,7 @@ table.coldividers td + td { border-left:1px solid gray; }
                   the document represents a transcription of the output of the dubbing workflow.</p>
                   <p><a>Script Events</a> in this type of script SHOULD contain <a>Translation</a> <a>Text</a> objects
                   in the <a>Target Recording Language</a>
-                  and MAY also contain <a>Original</a> <a>Text</a> objects from the <a>Original Language Dialogue List</a>
+                  and MAY also contain <a>Original</a> <a>Text</a> objects from the <a>Original Language Transcript</a>
                   or <a>Translation</a> <a>Text</a> objects in other languages for for context and quality verification.</p>
                   <aside class="note">Even though the output of the dubbing workflow is in the same language as those
                     <a>Text</a> objects with the matching language,
@@ -359,8 +372,9 @@ table.coldividers td + td { border-left:1px solid gray; }
                 </li>
               </ul>
             </p>
+            <p class="ednote">The following example is orphaned - move to the top of the section, before the enumerated script types?</p>
             <pre class="example">
-&lt;tt daptm:scriptType=&quot;DUBBING_DIALOGUE_LIST&quot;&gt;
+&lt;tt daptm:scriptType=&quot;ORIGINAL_TRANSCRIPT&quot;&gt;
 ...
 &lt;/tt&gt;
             </pre>
@@ -379,7 +393,7 @@ table.coldividers td + td { border-left:1px solid gray; }
               to the language being spoken for the longest duration, or to the language arbitrarily chosen by the author.</p>
             <p class="note">Text content is marked either as being either in the <a>Original</a> language or
               as being a <a>Translation</a> independently of the <a>Primary Language</a>, using the <a>Text Language Source</a> property.</p>
-            <aside class="example">An <a>Original Language Dialogue List</a> script is prepared for a video
+            <aside class="example">An <a>Original Language Transcript</a> script is prepared for a video
               containing dialogue in Danish and Swedish.
               The <a>Primary Language</a> is set to Danish by setting <code>xml:lang="da"</code> on the <code>&lt;tt&gt;</code> element.
               <a>Script Events</a> that contain Swedish <a>Text</a> override this by setting


### PR DESCRIPTION
Closes #87.

* Change `DUBBING_ORIGINAL_DIALOGUE_LIST` to `ORIGINAL_TRANSCRIPT` and change the name "Original Language Dialogue List" to "Original Language Transcript"
* Change `DUBBING_TRANSLATED_DIALOGUE_LIST` to `TRANSLATED_TRANSCRIPT` and change the name "Translated Dialogue List" to "Translated Transcript"
* Split out the list of script types that are Dubbing Scripts into a separate paragraph for readability.
* Propagate changes throughout the examples
* Add an Ed Note before Example 12 - looks like it's orphaned and needs to move higher up, possibly.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/pull/102.html" title="Last updated on Dec 16, 2022, 1:57 PM UTC (e8e771c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/102/b2a93ab...e8e771c.html" title="Last updated on Dec 16, 2022, 1:57 PM UTC (e8e771c)">Diff</a>