### PR TITLE
Add note about empty Text objects

### DIFF
--- a/index.html
+++ b/index.html
@@ -535,8 +535,10 @@ table.coldividers td + td { border-left:1px solid gray; }
             <li>Zero or more <a>Character Identifiers</a> indicating the <a>Characters</a> involved in this <a>Script Event</a>.
               <p class="note">While typically, a <a>Script Event</a> corresponds to one single <a>Character</a>, there are cases where multiple <a>characters</a> can be associated with a <a>Script Event</a>. This is when all <a>Characters</a> speak the same text at the same time.</p>
             </li>
-            <li>Zero or more <a>Text</a> objects, each representing either the <a>Original</a> language script or
-              <a>Translations</a> of the original language script in other languages.</li>
+            <li><p>Zero or more <a>Text</a> objects, each representing either the <a>Original</a> language script or
+              <a>Translations</a> of the original language script in other languages.
+              <p class="note">Empty <a>Text</a> objects can be used to indicate explicitly that there is no text content.
+                It is recommended that empty <a>Text</a> objects are not used as a workflow placeholder to indicate incomplete work.</p></li>
             <li>an optional <a>Script Event Description</a> property, as a human-readable description of the <a>Script Event</a>.</li>
             <li>an optional <a>On Screen</a> property, which is an annotation indicating the position of the <a>character</a> during the <a>Script Event</a></li>
           </ul>


### PR DESCRIPTION
Closes #68 by adding informative text recommending how empty Text objects should or should not be used, as per the discussion on the thread.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/pull/106.html" title="Last updated on Dec 23, 2022, 10:52 AM UTC (604e948)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/106/b2a93ab...604e948.html" title="Last updated on Dec 23, 2022, 10:52 AM UTC (604e948)">Diff</a>