### PR TITLE
Prohibit frame components in times

### DIFF
--- a/index.html
+++ b/index.html
@@ -1569,9 +1569,9 @@ daptm:eventType : string
           <h4>Time expressions</h4>
           <p>All time expressions within a document SHOULD use the same syntax,
             either <code>clock-time</code> or <code>offset-time</code>
-            as defined in [[ttml2]].</p>
+            as defined in [[ttml2]], with <a href="#features-and-extensions-section">DAPT constraints</a> applied.</p>
           <div class="example note">
-            <p>A <code>clock-time</code> has one of the forms:</p>
+            <p>A DAPT <code>clock-time</code> has one of the forms:</p>
             <ul>
               <li><code>hh:mm:ss.sss</code></li>
               <li><code>hh:mm:ss</code></li>

--- a/index.html
+++ b/index.html
@@ -1554,32 +1554,11 @@ daptm:eventType : string
             the computed begin time of its parent element,
             or for the <code>&lt;body&gt;</code> element, to time zero.</p>
         </section> <!-- timecontainer-section -->
-        <section id="framerate-section">
-          <h4><code>ttp:frameRate</code></h4>
-          <p>If the document contains any time expression that uses the <code>f</code> metric,
-            or any time expression that contains a frames component,
-            the <code>ttp:frameRate</code> attribute MUST be present on the <code>&lt;tt&gt;</code> element.</p>
-        </section> <!-- framerate-section -->
         <section id="tickrate-section">
           <h4><code>ttp:tickRate</code></h4>
           <p>If the document contains any time expression that uses the <code>t</code> metric,
             the <code>ttp:tickRate</code> attribute MUST be present on the <code>&lt;tt&gt;</code> element.</p>
         </section>
-        <section id="time-clock-with-frames-section" class="informative">
-          <h4><code>#time-clock-with-frames</code></h4>
-          <p>As specified in [[?ttml2]], a <code>#time-clock-with-frames</code> expression is translated to
-            a media time <code>M</code> according to
-            <br/>
-            <code>M = 3600 · hours + 60 · minutes + seconds + (frames ÷ (ttp:frameRateMultiplier · ttp:frameRate))</code>.</p>
-          <div class="example note">
-            <p>For example, the expression <code>01:23:45:15</code>,
-            where <code>ttp:frameRate=&quot;25&quot;</code> and <code>ttp:frameRateMultiplier</code> is unspecified,
-            and therefore the default of 1, is equivalent to a media time</p>
-            <pre>
-M = 3600 × 01 + 60 × 23 + 45 + (15 ÷ (1 × 25))
-  = 5025.6s</pre>
-            </div>
-        </section> <!-- time-clock-with-frames-section -->
         <section id="time-expression-section">
           <h4>Time expressions</h4>
           <p>All time expressions within a document SHOULD use the same syntax,
@@ -1590,17 +1569,14 @@ M = 3600 × 01 + 60 × 23 + 45 + (15 ÷ (1 × 25))
             <ul>
               <li><code>hh:mm:ss.sss</code></li>
               <li><code>hh:mm:ss</code></li>
-              <li><code>hh:mm:ss:ff</code></li>
-              <li><code>hh:mm:ss:ff.x</code></li>
+
             </ul>
              <p>
               where
               <code>hh</code> is hours,
               <code>mm</code> is minutes,
-              <code>ss</code> is seconds,
-              <code>ss.sss</code> is seconds with a decimal fraction of seconds (any precision),
-              <code>ff</code> is frames, and
-              <code>x</code> is sub-frames.
+              <code>ss</code> is seconds, and
+              <code>ss.sss</code> is seconds with a decimal fraction of seconds (any precision).
             </p>
           </div>
           <div class="example note">
@@ -1619,8 +1595,7 @@ M = 3600 × 01 + 60 × 23 + 45 + (15 ÷ (1 × 25))
               <li><code>h</code> for hours,</li>
               <li><code>m</code> for minutes,</li>
               <li><code>s</code> for seconds,</li>
-              <li><code>ms</code> for milliseconds,</li>
-              <li><code>f</code> for frames, and</li>
+              <li><code>ms</code> for milliseconds, and</li>
               <li><code>t</code> for ticks.</li>
             </ul>
           </div>
@@ -1632,6 +1607,12 @@ M = 3600 × 01 + 60 × 23 + 45 + (15 ÷ (1 × 25))
             A media time expression of 00:00:05.1 corresponds to frame 
             <code>ceiling( 5.1 × ( 1000 / 1001 × 30) ) = 153</code>
             of a video that has a frame rate of <code>1000 / 1001 × 30 ≈ 29.97</code>.
+          </p>
+          <p class="note">
+            Time expressions that use frame components, including "time code",
+            are prohibited due to the semantic confusion that has been observed
+            elsewhere when they are used, particularly with non-integer frame rates,
+            "drop modes" and sub-frame rates.
           </p>
   
         </section> <!-- time-expression-section -->
@@ -1994,14 +1975,12 @@ M = 3600 × 01 + 60 × 23 + 45 + (15 ÷ (1 × 25))
           </tr>
           <tr>
             <td><code>#frameRate</code></td>
-            <td><span class="permitted label">permitted</span></td>
-            <td>
-              See [[[#framerate-section]]].
-            </td>
+            <td><span class="prohibited label">prohibited</span></td>
+            <td></td>
           </tr>
           <tr>
             <td><code>#frameRateMultiplier</code></td>
-            <td><span class="permitted label">permitted</span></td>
+            <td><span class="prohibited label">prohibited</span></td>
             <td></td>
           </tr>
           <tr>
@@ -2162,7 +2141,7 @@ M = 3600 × 01 + 60 × 23 + 45 + (15 ÷ (1 × 25))
           </tr>
           <tr>
             <td><code>#subFrameRate</code></td>
-            <td><span class="permitted label">permitted</span></td>
+            <td><span class="prohibited label">prohibited</span></td>
             <td></td>
           </tr>
           <tr>
@@ -2177,13 +2156,13 @@ M = 3600 × 01 + 60 × 23 + 45 + (15 ÷ (1 × 25))
           </tr>
           <tr>
             <td><code>#time-clock-with-frames</code></td>
-            <td><span class="permitted label">permitted</span></td>
-            <td>See [[[#framerate-section]]] and [[[#time-clock-with-frames-section]]].</td>
+            <td><span class="prohibited label">prohibited</span></td>
+            <td></td>
           </tr>
           <tr>
             <td><code>#time-offset-with-frames</code></td>
-            <td><span class="permitted label">permitted</span></td>
-            <td>See [[[#framerate-section]]].</td>
+            <td><span class="prohibited label">prohibited</span></td>
+            <td></td>
           </tr>
           <tr>
             <td><code>#time-offset-with-ticks</code></td>

--- a/index.html
+++ b/index.html
@@ -1554,6 +1554,12 @@ daptm:eventType : string
             the computed begin time of its parent element,
             or for the <code>&lt;body&gt;</code> element, to time zero.</p>
         </section> <!-- timecontainer-section -->
+        <section id="framerate-section">
+          <h4><code>ttp:frameRate</code></h4>
+          <p>If the document contains any time expression that uses the <code>f</code> metric,
+            or any time expression that contains a frames component,
+            the <code>ttp:frameRate</code> attribute MUST be present on the <code>&lt;tt&gt;</code> element.</p>
+        </section> <!-- framerate-section -->
         <section id="tickrate-section">
           <h4><code>ttp:tickRate</code></h4>
           <p>If the document contains any time expression that uses the <code>t</code> metric,
@@ -1579,6 +1585,13 @@ daptm:eventType : string
               <code>ss.sss</code> is seconds with a decimal fraction of seconds (any precision).
             </p>
           </div>
+          <p class="note">
+            Clock time expressions that use frame components,
+            which look similar to "time code",
+            are prohibited due to the semantic confusion that has been observed
+            elsewhere when they are used, particularly with non-integer frame rates,
+            "drop modes" and sub-frame rates.
+          </p>
           <div class="example note">
             <p>An <code>offset-time</code> has one of the forms:</p>
             <ul>
@@ -1595,7 +1608,8 @@ daptm:eventType : string
               <li><code>h</code> for hours,</li>
               <li><code>m</code> for minutes,</li>
               <li><code>s</code> for seconds,</li>
-              <li><code>ms</code> for milliseconds, and</li>
+              <li><code>ms</code> for milliseconds,</li>
+              <li><code>f</code> for frames, and</li>
               <li><code>t</code> for ticks.</li>
             </ul>
           </div>
@@ -1607,12 +1621,6 @@ daptm:eventType : string
             A media time expression of 00:00:05.1 corresponds to frame 
             <code>ceiling( 5.1 × ( 1000 / 1001 × 30) ) = 153</code>
             of a video that has a frame rate of <code>1000 / 1001 × 30 ≈ 29.97</code>.
-          </p>
-          <p class="note">
-            Time expressions that use frame components, including "time code",
-            are prohibited due to the semantic confusion that has been observed
-            elsewhere when they are used, particularly with non-integer frame rates,
-            "drop modes" and sub-frame rates.
           </p>
   
         </section> <!-- time-expression-section -->
@@ -1975,12 +1983,14 @@ daptm:eventType : string
           </tr>
           <tr>
             <td><code>#frameRate</code></td>
-            <td><span class="prohibited label">prohibited</span></td>
-            <td></td>
+            <td><span class="permitted label">permitted</span></td>
+            <td>
+              See [[[#framerate-section]]].
+            </td>
           </tr>
           <tr>
             <td><code>#frameRateMultiplier</code></td>
-            <td><span class="prohibited label">prohibited</span></td>
+            <td><span class="permitted label">permitted</span></td>
             <td></td>
           </tr>
           <tr>
@@ -2161,8 +2171,8 @@ daptm:eventType : string
           </tr>
           <tr>
             <td><code>#time-offset-with-frames</code></td>
-            <td><span class="prohibited label">prohibited</span></td>
-            <td></td>
+            <td><span class="permitted label">permitted</span></td>
+            <td>See [[[#framerate-section]]].</td>
           </tr>
           <tr>
             <td><code>#time-offset-with-ticks</code></td>

--- a/profiles/dapt-content-profile.xml
+++ b/profiles/dapt-content-profile.xml
@@ -25,6 +25,8 @@
     <feature value="optional">#direction</feature>
     <feature value="optional">#embedded-audio</feature>
     <feature value="optional">#embedded-data</feature>
+    <feature value="optional">#frameRate</feature>
+    <feature value="optional">#frameRateMultiplier</feature>
     <feature value="optional">#gain</feature>
     <feature value="optional">#metadata</feature>
     <feature value="optional">#metadata-item</feature>
@@ -50,8 +52,9 @@
     <feature value="optional">#styling-referential</feature>
     <feature value="optional">#tickRate</feature>
     <feature value="optional">#time-clock</feature>
-    <feature value="optional">#time-offset-with-ticks</feature>
     <feature value="optional">#time-offset</feature>
+    <feature value="optional">#time-offset-with-frames</feature>
+    <feature value="optional">#time-offset-with-ticks</feature>
     <feature value="optional">#timing</feature>
     <feature value="optional">#unicodeBidi</feature>
     <feature value="optional">#unicodeBidi-isolate</feature>
@@ -67,14 +70,11 @@
     <feature value="prohibited">#dropMode-dropNTSC</feature>
     <feature value="prohibited">#dropMode-dropPAL</feature>
     <feature value="prohibited">#dropMode-nonDrop</feature>
-    <feature value="prohibited">#frameRate</feature>
-    <feature value="prohibited">#frameRateMultiplier</feature>
     <feature value="prohibited">#markerMode</feature>
     <feature value="prohibited">#markerMode-continuous</feature>
     <feature value="prohibited">#markerMode-discontinuous</feature>
     <feature value="prohibited">#subFrameRate</feature>
     <feature value="prohibited">#time-clock-with-frames</feature>
-    <feature value="prohibited">#time-offset-with-frames</feature>
     <feature value="prohibited">#time-wall-clock</feature>
     <feature value="prohibited">#timeBase-clock</feature>
     <feature value="prohibited">#timeBase-smpte</feature>

--- a/profiles/dapt-content-profile.xml
+++ b/profiles/dapt-content-profile.xml
@@ -25,8 +25,6 @@
     <feature value="optional">#direction</feature>
     <feature value="optional">#embedded-audio</feature>
     <feature value="optional">#embedded-data</feature>
-    <feature value="optional">#frameRate</feature>
-    <feature value="optional">#frameRateMultiplier</feature>
     <feature value="optional">#gain</feature>
     <feature value="optional">#metadata</feature>
     <feature value="optional">#metadata-item</feature>
@@ -50,11 +48,8 @@
     <feature value="optional">#styling-inheritance-content</feature>
     <feature value="optional">#styling-inline</feature>
     <feature value="optional">#styling-referential</feature>
-    <feature value="optional">#subFrameRate</feature>
     <feature value="optional">#tickRate</feature>
-    <feature value="optional">#time-clock-with-frames</feature>
     <feature value="optional">#time-clock</feature>
-    <feature value="optional">#time-offset-with-frames</feature>
     <feature value="optional">#time-offset-with-ticks</feature>
     <feature value="optional">#time-offset</feature>
     <feature value="optional">#timing</feature>
@@ -72,9 +67,14 @@
     <feature value="prohibited">#dropMode-dropNTSC</feature>
     <feature value="prohibited">#dropMode-dropPAL</feature>
     <feature value="prohibited">#dropMode-nonDrop</feature>
+    <feature value="prohibited">#frameRate</feature>
+    <feature value="prohibited">#frameRateMultiplier</feature>
     <feature value="prohibited">#markerMode</feature>
     <feature value="prohibited">#markerMode-continuous</feature>
     <feature value="prohibited">#markerMode-discontinuous</feature>
+    <feature value="prohibited">#subFrameRate</feature>
+    <feature value="prohibited">#time-clock-with-frames</feature>
+    <feature value="prohibited">#time-offset-with-frames</feature>
     <feature value="prohibited">#time-wall-clock</feature>
     <feature value="prohibited">#timeBase-clock</feature>
     <feature value="prohibited">#timeBase-smpte</feature>

--- a/profiles/dapt-processor-profile.xml
+++ b/profiles/dapt-processor-profile.xml
@@ -21,6 +21,8 @@
     <feature value="required">#direction</feature>
     <feature value="required">#embedded-audio</feature>
     <feature value="required">#embedded-data</feature>
+    <feature value="required">#frameRate</feature>
+    <feature value="required">#frameRateMultiplier</feature>
     <feature value="required">#gain</feature>
     <feature value="required">#metadata</feature>
     <feature value="required">#metadata-item</feature>
@@ -43,8 +45,9 @@
     <feature value="required">#styling-referential</feature>
     <feature value="required">#tickRate</feature>
     <feature value="required">#time-clock</feature>
-    <feature value="required">#time-offset-with-ticks</feature>
     <feature value="required">#time-offset</feature>
+    <feature value="required">#time-offset-with-frames</feature>
+    <feature value="required">#time-offset-with-ticks</feature>
     <feature value="required">#timeBase-media</feature>
     <feature value="required">#timing</feature>
     <feature value="required">#transformation</feature>
@@ -63,8 +66,6 @@
     <feature value="optional">#dropMode-dropNTSC</feature>
     <feature value="optional">#dropMode-dropPAL</feature>
     <feature value="optional">#dropMode-nonDrop</feature>
-    <feature value="optional">#frameRate</feature>
-    <feature value="optional">#frameRateMultiplier</feature>
     <feature value="optional">#markerMode</feature>
     <feature value="optional">#markerMode-continuous</feature>
     <feature value="optional">#markerMode-discontinuous</feature>
@@ -74,7 +75,6 @@
     <feature value="optional">#processorProfiles-combined</feature>
     <feature value="optional">#subFrameRate</feature>
     <feature value="optional">#time-clock-with-frames</feature>
-    <feature value="optional">#time-offset-with-frames</feature>
     <feature value="optional">#time-wall-clock</feature>
     <feature value="optional">#timeBase-clock</feature>
     <feature value="optional">#timeBase-smpte</feature>

--- a/profiles/dapt-processor-profile.xml
+++ b/profiles/dapt-processor-profile.xml
@@ -21,8 +21,6 @@
     <feature value="required">#direction</feature>
     <feature value="required">#embedded-audio</feature>
     <feature value="required">#embedded-data</feature>
-    <feature value="required">#frameRate</feature>
-    <feature value="required">#frameRateMultiplier</feature>
     <feature value="required">#gain</feature>
     <feature value="required">#metadata</feature>
     <feature value="required">#metadata-item</feature>
@@ -43,11 +41,8 @@
     <feature value="required">#styling-inheritance-content</feature>
     <feature value="required">#styling-inline</feature>
     <feature value="required">#styling-referential</feature>
-    <feature value="required">#subFrameRate</feature>
     <feature value="required">#tickRate</feature>
-    <feature value="required">#time-clock-with-frames</feature>
     <feature value="required">#time-clock</feature>
-    <feature value="required">#time-offset-with-frames</feature>
     <feature value="required">#time-offset-with-ticks</feature>
     <feature value="required">#time-offset</feature>
     <feature value="required">#timeBase-media</feature>
@@ -68,6 +63,8 @@
     <feature value="optional">#dropMode-dropNTSC</feature>
     <feature value="optional">#dropMode-dropPAL</feature>
     <feature value="optional">#dropMode-nonDrop</feature>
+    <feature value="optional">#frameRate</feature>
+    <feature value="optional">#frameRateMultiplier</feature>
     <feature value="optional">#markerMode</feature>
     <feature value="optional">#markerMode-continuous</feature>
     <feature value="optional">#markerMode-discontinuous</feature>
@@ -75,6 +72,9 @@
     <feature value="optional">#permitFeatureWidening</feature>
     <feature value="optional">#processorProfiles</feature>
     <feature value="optional">#processorProfiles-combined</feature>
+    <feature value="optional">#subFrameRate</feature>
+    <feature value="optional">#time-clock-with-frames</feature>
+    <feature value="optional">#time-offset-with-frames</feature>
     <feature value="optional">#time-wall-clock</feature>
     <feature value="optional">#timeBase-clock</feature>
     <feature value="optional">#timeBase-smpte</feature>


### PR DESCRIPTION
Closes #123.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/pull/127.html" title="Last updated on Apr 10, 2023, 12:58 PM UTC (14589e1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/127/daf097f...14589e1.html" title="Last updated on Apr 10, 2023, 12:58 PM UTC (14589e1)">Diff</a>