### PR TITLE
Address #130 tt element in correct namespace is what's important

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,7 +251,7 @@ table.coldividers td + td { border-left:1px solid gray; }
         <h3>Example documents</h3>
         <h4>Basic document structure</h4>
         <p>The top level structure of a document is as follows.
-          The <code>xmlns</code> attribute and the <code>&lt;tt&gt;</code> element indicate that this is a TTML document
+          The <code>&lt;tt&gt;</code> root element in the namespace <code>http://www.w3.org/ns/ttml</code> indicates that this is a TTML document
           and the <a><code>ttp:contentProfiles</code></a> attribute indicates that it adheres to the DAPT <a>content profile</a> defined in this specification.
           The <code>daptm:scriptType</code> attribute indicates the type of script
           but in this empty example, it is not relevant, as only the structure of the document is shown.


### PR DESCRIPTION
Clarify that it's the `<tt>` root element in the stated namespace that indicates the TTML document, not the `xmlns` attribute.

Closes #130.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/pull/131.html" title="Last updated on Apr 17, 2023, 9:26 AM UTC (a127fd6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/131/daf097f...a127fd6.html" title="Last updated on Apr 17, 2023, 9:26 AM UTC (a127fd6)">Diff</a>