### PR TITLE
removed wrong reference section id

### DIFF
--- a/index.html
+++ b/index.html
@@ -360,7 +360,7 @@ table.coldividers td + td { border-left:1px solid gray; }
         and when making reference to <dfn data-cite="ttml2#terms-processor">Processor</dfn> conformance,
         these designations refer to processing requirements associated with each designated <a>Feature</a> or <a>Extension</a>.
         If the name of an element referenced in this specification is not namespace qualified,
-        then the TT namespace applies (see <a href="#namespaces">9.3 Namespaces</a>.)
+        then the TT namespace applies (see <a href="#namespaces"></a>.)
       </p>
     </section>
 


### PR DESCRIPTION
Link text contains section ID, but it's wrong now.
Let respec auto generate link text with generated section ID.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/dapt/pull/133.html" title="Last updated on Apr 18, 2023, 1:27 PM UTC (833ea11)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/133/a2b8c06...himorin:833ea11.html" title="Last updated on Apr 18, 2023, 1:27 PM UTC (833ea11)">Diff</a>