### PR TITLE
possible typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -475,7 +475,7 @@ table.coldividers td + td { border-left:1px solid gray; }
                 <p><a>Script Events</a> in this type of <a>script</a> SHOULD contain <a>Translation</a> <a>Text</a> objects
                   in the <a>Target Recording Language</a>
                   and MAY also contain <a>Original</a> <a>Text</a> objects from the <a>Original Language Transcript</a>
-                  or <a>Translation</a> <a>Text</a> objects in other languages for for context and quality verification.</p>
+                  or <a>Translation</a> <a>Text</a> objects in other languages for context and quality verification.</p>
                   <aside class="note">Even though the output of the dubbing workflow is in the same language as those
                   <a>Text</a> objects with the matching language,
                   the <a>Text Language Source</a> of those Text objects remains <a>Translation</a>


### PR DESCRIPTION
I believe this should be a typo.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/dapt/pull/134.html" title="Last updated on Apr 18, 2023, 1:30 PM UTC (2678763)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/134/a2b8c06...himorin:2678763.html" title="Last updated on Apr 18, 2023, 1:30 PM UTC (2678763)">Diff</a>