### PR TITLE
Calculation of timing properties for end on both End and Duration are defined

### DIFF
--- a/index.html
+++ b/index.html
@@ -568,7 +568,7 @@ table.coldividers td + td { border-left:1px solid gray; }
                 and is relative to the active begin time of the parent object.</li>
               <li>The <dfn>Duration</dfn> property defines the maximum duration of an object.</li>
                 <p class="note">If both an <a>End</a> and a <a>Duration</a> property are present,
-                  the end time is the earlier of <a>Begin</a> and <a>Begin</a> + <a>Duration</a>.</p>
+                  the end time is the earlier of <a>End</a> and <a>Begin</a> + <a>Duration</a>.</p>
             </ul>
             <div class="note">If any of the <a>timing properties</a> is omitted, the following rules apply:
               <ul>


### PR DESCRIPTION
I believe we need this fix. Comparing Begin with Begin + Duration and picking the earlier results into Begin always.

Also, I wonder whether this Note: part (and following one also?) should be normative or not. It seems for me, these two notes define exceptional behaviors, which we cannot tell from current normative definitions and also no other normative text says anything about this.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/dapt/pull/135.html" title="Last updated on Apr 18, 2023, 1:40 PM UTC (cd8694f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/135/a2b8c06...himorin:cd8694f.html" title="Last updated on Apr 18, 2023, 1:40 PM UTC (cd8694f)">Diff</a>