### PR TITLE
possible fix for namespace table

### DIFF
--- a/index.html
+++ b/index.html
@@ -1355,7 +1355,7 @@ daptm:eventType : string
             </tr>
             <tr>
               <td>TT Audio Style</td>
-              <td><em>tta:</em></td>
+              <td><code>tta</code></td>
               <td><code>http://www.w3.org/ns/ttml#audio</code></td>
               <td>[[ttml2]]</td>
             </tr>


### PR DESCRIPTION
This has not been changed since the first ED in adpt, but I felt no reason that only `tta` is marked up differently.

https://github.com/w3c/adpt/commit/03844f0e95c6fdc320d0c6aa0b2ad105f8338b77