### PR TITLE
added GHAction for streamlined publication

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -1,0 +1,29 @@
+name: Build, and publish spec to GitHub Pages and /TR/
+
+on:
+  pull_request: {}
+  push:
+    branches: [main]
+    paths:
+      - 'index.html'
+      - 'examples/**.xml'
+      - 'figures/**.svg'
+      - 'profiles/**.xml'
+
+jobs:
+  main:
+    name: Build, Validate and Deploy
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: w3c/spec-prod@v2
+        with:
+          TOOLCHAIN: respec
+          SOURCE: index.html
+          W3C_ECHIDNA_TOKEN: ${{ secrets.W3C_TR_TOKEN }}
+          W3C_WG_DECISION_URL: https://www.w3.org/2023/04/13-tt-minutes.html#x059
+          W3C_BUILD_OVERRIDE: |
+            specStatus: WD
+
+# not set 'warning' to BUILD_FAIL_ON (not to cause error by bikeshed warning?)
+


### PR DESCRIPTION
as title

I suppose we'd better to keep three directories in `path`, but if removing some (like `examples`) should be better, please let me know.