### PR TITLE
Add AD workflow type examples

### DIFF
--- a/examples/intro-original-language-with-dub-language-and-adaptation.xml
+++ b/examples/intro-original-language-with-dub-language-and-adaptation.xml
@@ -3,7 +3,7 @@
     xmlns:daptm="http://www.w3.org/ns/ttml/profile/dapt#metadata"
     xml:lang="en"
     ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/dapt1.0/content"
-    daptm:applicationType="dubbing"
+    daptm:workflowType="dubbing"
     daptm:scriptType="preRecording">
   <head>
     <metadata>

--- a/examples/intro-original-language-with-dub-language.xml
+++ b/examples/intro-original-language-with-dub-language.xml
@@ -3,7 +3,7 @@
     xmlns:daptm="http://www.w3.org/ns/ttml/profile/dapt#metadata"
     xml:lang="en"
     ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/dapt1.0/content"
-    daptm:applicationType="dubbing"
+    daptm:workflowType="dubbing"
     daptm:scriptType="translatedTranscript">
   <head>
     <metadata>

--- a/examples/intro-original-language.xml
+++ b/examples/intro-original-language.xml
@@ -3,7 +3,7 @@
     xmlns:daptm="http://www.w3.org/ns/ttml/profile/dapt#metadata"
     xml:lang="fr" 
     ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/dapt1.0/content"
-    daptm:applicationType="dubbing"
+    daptm:workflowType="dubbing"
     daptm:scriptType="originalTranscript">
   <head>
     <metadata>

--- a/examples/intro-script-with-gain.xml
+++ b/examples/intro-script-with-gain.xml
@@ -1,4 +1,8 @@
-...
+<tt ...
+  daptm:workflowType="audioDescription"
+  daptm:scriptType="asRecorded"
+  xml:lang="en">
+  ...
     <div begin="25s" end="28s">
       <p daptm:langSrc="original">
         <animate begin="0.0s" end="0.3s" tta:gain="1;0.39" fill="freeze"/>

--- a/examples/intro-times-and-text.xml
+++ b/examples/intro-times-and-text.xml
@@ -1,4 +1,11 @@
-...
+<tt xmlns="http://www.w3.org/ns/ttml"
+  xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+  xmlns:daptm="http://www.w3.org/ns/ttml/profile/dapt#metadata"
+  xmlns:xml="http://www.w3.org/XML/1998/namespace"
+  ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/dapt1.0/content"
+  daptm:workflowType="audioDescription"
+  daptm:scriptType="preRecording"
+  xml:lang="en">
   <body>
     <div begin="10s" end="13s">
       <p daptm:langSrc="original">
@@ -11,4 +18,4 @@
       </p>
     </div>
   </body>
-...
+</tt>

--- a/examples/intro-top-level.xml
+++ b/examples/intro-top-level.xml
@@ -3,7 +3,7 @@
     xmlns:daptm="http://www.w3.org/ns/ttml/profile/dapt#metadata"
     xml:lang="en" 
     ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/dapt1.0/content"
-    daptm:applicationType="dubbing"
+    daptm:workflowType="dubbing"
     daptm:scriptType="originalTranscript">
   <head>
     <metadata>

--- a/examples/sourceMediaIdentifier.xml
+++ b/examples/sourceMediaIdentifier.xml
@@ -4,7 +4,7 @@
     xmlns:ebuttm="urn:ebu:tt:metadata"
     xml:lang="en" 
     ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/dapt1.0/content"
-    daptm:applicationType="dubbing"
+    daptm:workflowType="dubbing"
     daptm:scriptType="originalTranscript">
   <head>
     <metadata>

--- a/index.html
+++ b/index.html
@@ -275,7 +275,7 @@ table.coldividers td + td { border-left:1px solid gray; }
         <p>The following examples will demonstrate different uses in dubbing and audio description workflows.</p>
 
         <h4>Audio Description Examples</h4>
-        <p>When descriptions are added this becomes a Pre Recording <a>Script</a>:</p>
+        <p>When descriptions are added this becomes a <a>Pre-Recording Script</a>:</p>
         <pre class="example"
           data-include="examples/intro-times-and-text.xml"
           data-include-format="text">


### PR DESCRIPTION
Closes #137

Also fixed some other examples that wrongly had `applicationType` instead of `workflowType`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/pull/145.html" title="Last updated on May 19, 2023, 11:10 AM UTC (9462d0c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/145/8da4b16...9462d0c.html" title="Last updated on May 19, 2023, 11:10 AM UTC (9462d0c)">Diff</a>