### PR TITLE
fix XML syntax in example

### DIFF
--- a/index.html
+++ b/index.html
@@ -978,8 +978,8 @@ daptm:eventType : string
 ...
 &lt;div xml:id=&quot;event_1&quot;
      begin=&quot;9663f&quot; end=&quot;9682f&quot; 
-     ttm:agent=&quot;character_4&quot;&gt;
-     daptm:eventType=&quot;dialogue&quot;
+     ttm:agent=&quot;character_4&quot;
+     daptm:eventType=&quot;dialogue&quot;&gt;
 ...
 &lt;/div&gt;
 ...


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/pull/156.html" title="Last updated on Jun 14, 2023, 4:54 PM UTC (d0c701c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/156/3b9e751...d0c701c.html" title="Last updated on Jun 14, 2023, 4:54 PM UTC (d0c701c)">Diff</a>