### PR TITLE
Try using actions/checkout@v3

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build, Validate and Deploy
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2
         with:
           TOOLCHAIN: respec


### PR DESCRIPTION
Fix build issue caused by previous version of actions/checkout@v2 requiring node 12, which is no longer supported. This version requires node 16, which is supported.