### PR TITLE
Split Script Event Description out as a separate object

### DIFF
--- a/figures/class-diagram.svg
+++ b/figures/class-diagram.svg
@@ -1,399 +1,423 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="1242px" preserveAspectRatio="none" style="width:1051px;height:1242px;background:#FFFFFF;" version="1.1" viewBox="0 0 1051 1242" width="1051px" zoomAndPan="magnify"><defs/><g><!--MD5=[ba84c569c07e3989de82fef30200dade]
-class DAPTScript--><g id="elem_DAPTScript"><rect fill="#FFFFFF" height="125.375" id="DAPTScript" rx="2.5" ry="2.5" style="stroke:#000000;stroke-width:1.0;" width="220" x="404" y="12"/><a href="#dapt-script" target="_top" xlink:actuate="onRequest" xlink:href="#dapt-script" xlink:show="new" xlink:title="#dapt-script" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-weight="bold" lengthAdjust="spacing" textLength="98" x="465" y="36.4688">DAPT Script</text></a><line style="stroke:#000000;stroke-width:1.0;" x1="405" x2="623" y1="48.8438" y2="48.8438"/><a href="#workflow-type" target="_top" xlink:actuate="onRequest" xlink:href="#workflow-type" xlink:show="new" xlink:title="#workflow-type" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="115" x="414" y="72.3125">Workflow Type</text></a><a href="#script-type" target="_top" xlink:actuate="onRequest" xlink:href="#script-type" xlink:show="new" xlink:title="#script-type" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="87" x="414" y="99.1563">Script Type</text></a><a href="#primary-language" target="_top" xlink:actuate="onRequest" xlink:href="#primary-language" xlink:show="new" xlink:title="#primary-language" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="141" x="414" y="126">Primary Language</text></a></g><!--MD5=[23a68826f062503ff688839683b99b89]
-class ScriptEvent--><g id="elem_ScriptEvent"><rect fill="#FFFFFF" height="232.75" id="ScriptEvent" rx="2.5" ry="2.5" style="stroke:#000000;stroke-width:1.0;" width="287" x="313" y="223.5"/><a href="#script-event" target="_top" xlink:actuate="onRequest" xlink:href="#script-event" xlink:show="new" xlink:title="#script-event" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-weight="bold" lengthAdjust="spacing" textLength="97" x="408" y="247.9688">Script Event</text></a><line style="stroke:#000000;stroke-width:1.0;" x1="314" x2="599" y1="260.3438" y2="260.3438"/><a href="#dfn-script-event-identifier" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-script-event-identifier" xlink:show="new" xlink:title="#dfn-script-event-identifier" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="169" x="323" y="283.8125">Script Event Identifier</text></a><a href="#dfn-begin" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-begin" xlink:show="new" xlink:title="#dfn-begin" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-style="italic" lengthAdjust="spacing" textLength="123" x="323" y="310.6563">(optional) Begin</text></a><a href="#dfn-end" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-end" xlink:show="new" xlink:title="#dfn-end" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-style="italic" lengthAdjust="spacing" textLength="109" x="323" y="337.5">(optional) End</text></a><a href="#dfn-duration" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-duration" xlink:show="new" xlink:title="#dfn-duration" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-style="italic" lengthAdjust="spacing" textLength="149" x="323" y="364.3438">(optional) Duration</text></a><a href="#dfn-script-event-type" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-script-event-type" xlink:show="new" xlink:title="#dfn-script-event-type" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="214" x="323" y="391.1875">(optional) Script Event Type</text></a><a href="#dfn-script-event-description" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-script-event-description" xlink:show="new" xlink:title="#dfn-script-event-description" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="267" x="323" y="418.0313">(optional) Script Event Description</text></a><a href="#on-screen" target="_top" xlink:actuate="onRequest" xlink:href="#on-screen" xlink:show="new" xlink:title="#on-screen" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="159" x="323" y="444.875">(optional) On Screen</text></a></g><!--MD5=[02a8746eb15ecbb4566dafa16ea4db73]
-class Text--><g id="elem_Text"><rect fill="#FFFFFF" height="125.375" id="Text" rx="2.5" ry="2.5" style="stroke:#000000;stroke-width:1.0;" width="220" x="347" y="568.5"/><a href="#text" target="_top" xlink:actuate="onRequest" xlink:href="#text" xlink:show="new" xlink:title="#text" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-weight="bold" lengthAdjust="spacing" textLength="35" x="439.5" y="592.9688">Text</text></a><line style="stroke:#000000;stroke-width:1.0;" x1="348" x2="566" y1="605.3438" y2="605.3438"/><a href="#dfn-text" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-text" xlink:show="new" xlink:title="#dfn-text" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="99" x="357" y="628.8125">Text content</text></a><a href="#text-language-source" target="_top" xlink:actuate="onRequest" xlink:href="#text-language-source" xlink:show="new" xlink:title="#text-language-source" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="174" x="357" y="655.6563">Text Language Source</text></a><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="156" x="357" y="682.5">(optional) Language</text></g><!--MD5=[4e8cc7bbb60dc5d148cf8b942067baf3]
-class Audio--><g id="elem_Audio"><rect fill="#FFFFFF" height="36.8438" id="Audio" rx="2.5" ry="2.5" style="stroke:#000000;stroke-width:1.0;" width="220" x="306" y="864.5"/><a href="#dfn-audio" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-audio" xlink:show="new" xlink:title="#dfn-audio" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-style="italic" font-weight="bold" lengthAdjust="spacing" textLength="49" x="391.5" y="888.9688">Audio</text></a></g><polygon fill="none" points="430.0776,901.3438,447.7832,912.9846,436.6594,921.4852" style="stroke:#000000;stroke-width:1.0;"/><line style="stroke:#000000;stroke-width:1.0;" x1="442.2213" x2="460" y1="917.2349" y2="940.5"/><polygon fill="none" points="378.4064,901.3438,363.527,916.4303,357.3665,903.8586" style="stroke:#000000;stroke-width:1.0;"/><line style="stroke:#000000;stroke-width:1.0;" x1="360.4468" x2="298.5" y1="910.1444" y2="940.5"/><line style="stroke:#000000;stroke-width:1.0;" x1="430.7464" x2="446.5" y1="864.5" y2="844.82"/><!--MD5=[94905989464663cf33e46e868b4be784]
-class SynthesizedAudio--><g id="elem_SynthesizedAudio"><rect fill="#FFFFFF" height="98.5313" id="SynthesizedAudio" rx="2.5" ry="2.5" style="stroke:#000000;stroke-width:1.0;" width="220" x="350" y="1070"/><a href="#dfn-synthesized-audio" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-synthesized-audio" xlink:show="new" xlink:title="#dfn-synthesized-audio" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-weight="bold" lengthAdjust="spacing" textLength="152" x="384" y="1094.4688">Synthesized Audio</text></a><line style="stroke:#000000;stroke-width:1.0;" x1="351" x2="569" y1="1106.8438" y2="1106.8438"/><a href="#dfn-rate" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-rate" xlink:show="new" xlink:title="#dfn-rate" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="34" x="360" y="1130.3125">Rate</text></a><a href="#dfn-pitch" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-pitch" xlink:show="new" xlink:title="#dfn-pitch" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="118" x="360" y="1157.1563">(optional) Pitch</text></a></g><!--MD5=[dc7ce40dd9d22a10246a6e3b01b316d1]
-class AudioRecording--><g id="elem_AudioRecording"><rect fill="#FFFFFF" height="232.75" id="AudioRecording" rx="2.5" ry="2.5" style="stroke:#000000;stroke-width:1.0;" width="220" x="115" y="1003"/><a href="#dfn-audio-recording" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-audio-recording" xlink:show="new" xlink:title="#dfn-audio-recording" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-weight="bold" lengthAdjust="spacing" textLength="138" x="156" y="1027.4688">Audio Recording</text></a><line style="stroke:#000000;stroke-width:1.0;" x1="116" x2="334" y1="1039.8438" y2="1039.8438"/><a href="#dfn-source" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-source" xlink:show="new" xlink:title="#dfn-source" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="73" x="125" y="1063.3125">Source [ ]</text></a><a href="#dfn-type" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-type" xlink:show="new" xlink:title="#dfn-type" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="57" x="125" y="1090.1563">Type [ ]</text></a><a href="#dfn-begin" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-begin" xlink:show="new" xlink:title="#dfn-begin" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-style="italic" lengthAdjust="spacing" textLength="123" x="125" y="1117">(optional) Begin</text></a><a href="#dfn-end" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-end" xlink:show="new" xlink:title="#dfn-end" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-style="italic" lengthAdjust="spacing" textLength="109" x="125" y="1143.8438">(optional) End</text></a><a href="#dfn-duration" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-duration" xlink:show="new" xlink:title="#dfn-duration" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-style="italic" lengthAdjust="spacing" textLength="149" x="125" y="1170.6875">(optional) Duration</text></a><a href="#dfn-in-time" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-in-time" xlink:show="new" xlink:title="#dfn-in-time" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="139" x="125" y="1197.5313">(optional) In Time</text></a><a href="#dfn-out-time" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-out-time" xlink:show="new" xlink:title="#dfn-out-time" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="152" x="125" y="1224.375">(optional) Out Time</text></a></g><!--MD5=[3eff9d4279c887ef9286477750bdaaff]
-class Character--><g id="elem_Character"><rect fill="#FFFFFF" height="125.375" id="Character" rx="2.5" ry="2.5" style="stroke:#000000;stroke-width:1.0;" width="220" x="680" y="277.5"/><a href="#character" target="_top" xlink:actuate="onRequest" xlink:href="#character" xlink:show="new" xlink:title="#character" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-weight="bold" lengthAdjust="spacing" textLength="78" x="751" y="301.9688">Character</text></a><line style="stroke:#000000;stroke-width:1.0;" x1="681" x2="899" y1="314.3438" y2="314.3438"/><a href="#dfn-character-identifier" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-character-identifier" xlink:show="new" xlink:title="#dfn-character-identifier" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="153" x="690" y="337.8125">Character Identifier</text></a><a href="#dfn-character-name" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-character-name" xlink:show="new" xlink:title="#dfn-character-name" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="45" x="690" y="364.6563">Name</text></a><a href="#dfn-character-talent-name" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-character-talent-name" xlink:show="new" xlink:title="#dfn-character-talent-name" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="179" x="690" y="391.5">(optional) Talent Name</text></a></g><!--MD5=[f84229a7658f804a248f87f24502d86f]
-class Style--><g id="elem_Style"><rect fill="#FFFFFF" height="125.375" id="Style" rx="2.5" ry="2.5" style="stroke:#000000;stroke-width:1.0;" width="253" x="754" y="568.5"/><text fill="#000000" font-family="sans-serif" font-size="16" font-weight="bold" lengthAdjust="spacing" textLength="38" x="861.5" y="592.9688">Style</text><line style="stroke:#000000;stroke-width:1.0;" x1="755" x2="1006" y1="605.3438" y2="605.3438"/><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="114" x="764" y="628.8125">Style Identifier</text><a href="#dfn-character-identifier" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-character-identifier" xlink:show="new" xlink:title="#dfn-character-identifier" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="233" x="764" y="655.6563">(optional) Character Identifier</text></a><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="120" x="764" y="682.5">Style Attributes</text></g><!--MD5=[38ea2b49036364d20569c137fcddc05c]
-class MixingInstruction--><g id="elem_MixingInstruction"><rect fill="#FFFFFF" height="205.9063" id="MixingInstruction" rx="2.5" ry="2.5" style="stroke:#000000;stroke-width:1.0;" width="220" x="12" y="237.5"/><a href="#dfn-mixing-instruction" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-mixing-instruction" xlink:show="new" xlink:title="#dfn-mixing-instruction" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-weight="bold" lengthAdjust="spacing" textLength="151" x="46.5" y="261.9688">Mixing Instruction</text></a><line style="stroke:#000000;stroke-width:1.0;" x1="13" x2="231" y1="274.3438" y2="274.3438"/><a href="#dfn-gain" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-gain" xlink:show="new" xlink:title="#dfn-gain" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="116" x="22" y="297.8125">(optional) Gain</text></a><a href="#dfn-pan" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-pan" xlink:show="new" xlink:title="#dfn-pan" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="108" x="22" y="324.6563">(optional) Pan</text></a><a href="#dfn-begin" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-begin" xlink:show="new" xlink:title="#dfn-begin" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-style="italic" lengthAdjust="spacing" textLength="123" x="22" y="351.5">(optional) Begin</text></a><a href="#dfn-end" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-end" xlink:show="new" xlink:title="#dfn-end" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-style="italic" lengthAdjust="spacing" textLength="109" x="22" y="378.3438">(optional) End</text></a><a href="#dfn-duration" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-duration" xlink:show="new" xlink:title="#dfn-duration" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-style="italic" lengthAdjust="spacing" textLength="149" x="22" y="405.1875">(optional) Duration</text></a><a href="#dfn-fill" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-fill" xlink:show="new" xlink:title="#dfn-fill" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="104" x="22" y="432.0313">(optional) Fill</text></a></g><!--MD5=[9a69f825aa2371ff4e3b59c0d145921b]
-reverse link DAPTScript to ScriptEvent--><g id="link_DAPTScript_ScriptEvent"><path d="M513.75,151.82 C513.75,151.82 513.75,223.68 513.75,223.68 " fill="none" id="DAPTScript-backto-ScriptEvent" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="513.75,138.82,509.75,144.82,513.75,150.82,517.75,144.82,513.75,138.82" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="441.75,180.4053,444.6889,171.3602,438.8111,171.3602,441.75,180.4053" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="54" x="454.75" y="180.3184">contains</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="486.4543" y="208.6793">0..*</text></g><!--MD5=[4212e8dcb450f4d2a7c98f17ffac9132]
-reverse link DAPTScript to Character--><g id="link_DAPTScript_Character"><path d="M638.79,106.5 C638.79,106.5 790,106.5 790,106.5 C790,106.5 790,208.48 790,277.8 " fill="none" id="DAPTScript-backto-Character" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="625.79,106.5,631.79,110.5,637.79,106.5,631.79,102.5,625.79,106.5" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="721.3089,100.5991,717.5264,91.873,713.1197,95.7629,721.3089,100.5991" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="54" x="731" y="94.1084">contains</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="4" x="781" y="109.4189"> </text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="762.2656" y="262.8431">0..*</text></g><!--MD5=[83a66375c1104cb9dd87977bf190b50a]
-reverse link DAPTScript to Style--><g id="link_DAPTScript_Style"><path d="M638.86,43.5 C638.86,43.5 995,43.5 995,43.5 C995,43.5 995,416.89 995,568.58 " fill="none" id="DAPTScript-backto-Style" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="625.86,43.5,631.86,47.5,637.86,43.5,631.86,39.5,625.86,43.5" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="925.8066,119.7633,923.1616,110.6279,918.2972,113.9273,925.8066,119.7633" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="54" x="936" y="120.5384">contains</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="1014.4359" y="553.5976">0..*</text></g><!--MD5=[1f46cb9f2c928142c496b6a8b5d1357c]
-link DAPTScript to Style--><!--MD5=[d7948a54640a664a12c969cd73131365]
-reverse link Character to Style--><g id="link_Character_Style"><a href="#dfn-character-style" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-character-style" xlink:show="new" xlink:title="#dfn-character-style" xlink:type="simple"><path d="M859.17,408.73 C859.17,408.73 859.17,568.62 859.17,568.62 " fill="none" id="Character-backto-Style" style="stroke:#000000;stroke-width:1.0;stroke-dasharray:7.0,7.0;"/><polygon fill="#000000" points="859.17,403.73,855.17,412.73,859.17,408.73,863.17,412.73,859.17,403.73" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="60" x="794.17" y="466.2484">Character</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="30" x="824.17" y="481.5589">Style</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="24" x="828.8553" y="427.3085">0..1</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="828.9693" y="553.6423">0..*</text></a></g><!--MD5=[2713fb4f0ce800ca46dc62865f6d7616]
-link Character to Style--><!--MD5=[f594398502f34a6b884aa79a079fe2d3]
-link ScriptEvent to Style--><g id="link_ScriptEvent_Style"><a href="#dfn-character-style" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-character-style" xlink:show="new" xlink:title="#dfn-character-style" xlink:type="simple"><path d="M607.25,339.55 C607.25,343.39 607.25,589.5 607.25,589.5 C607.25,589.5 747.63,589.5 747.63,589.5 " fill="none" id="ScriptEvent-to-Style" style="stroke:#000000;stroke-width:1.0;stroke-dasharray:7.0,7.0;"/><polygon fill="#000000" points="752.63,589.5,743.63,585.5,747.63,589.5,743.63,593.5,752.63,589.5" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="60" x="542.25" y="512.2884">Character</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="30" x="572.25" y="527.5989">Style</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="612.027" y="356.1715">0..*</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="719.9676" y="580.0024">0..*</text></a></g><!--MD5=[9992307747bb78cc3931819c090826c5]
-link MixingInstruction to ScriptEvent--><g id="link_MixingInstruction_ScriptEvent"><path d="M231.69,339.5 C231.69,339.5 298.71,339.5 298.71,339.5 " fill="none" id="MixingInstruction-to-ScriptEvent" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="311.71,339.5,305.71,335.5,299.71,339.5,305.71,343.5,311.71,339.5" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="207.45,352.1553,216.4951,355.0942,216.4951,349.2163,207.45,352.1553" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="54" x="225.45" y="357.0684">contains</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="244.0676" y="332.2421">0..*</text></g><!--MD5=[0df1842c479b8ac7c242c98afbfee682]
-link Text to Style--><g id="link_Text_Style"><a href="#dfn-character-style" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-character-style" xlink:show="new" xlink:title="#dfn-character-style" xlink:type="simple"><path d="M566.74,630.5 C566.74,630.5 747.55,630.5 747.55,630.5 " fill="none" id="Text-to-Style" style="stroke:#000000;stroke-width:1.0;stroke-dasharray:7.0,7.0;"/><polygon fill="#000000" points="752.55,630.5,743.55,626.5,747.55,630.5,743.55,634.5,752.55,630.5" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="60" x="662.15" y="648.0684">Character</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="30" x="677.15" y="663.3789">Style</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="579.121" y="623.2599">0..*</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="719.883" y="623.3727">0..*</text></a></g><!--MD5=[0df1842c479b8ac7c242c98afbfee682]
-link Text to Style--><g id="link_Text_Style_other"><path d="M566.74,672.5 C566.74,672.5 747.55,672.5 747.55,672.5 " fill="none" id="Text-to-Style-1" style="stroke:#000000;stroke-width:1.0;stroke-dasharray:7.0,7.0;"/><polygon fill="#000000" points="752.55,672.5,743.55,668.5,747.55,672.5,743.55,676.5,752.55,672.5" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="35" x="617.15" y="650.0684">Other</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="30" x="619.65" y="665.3789">Style</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="579.121" y="668.0818">0..*</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="719.883" y="692.1306">0..*</text></g><!--MD5=[a7035052add2a35a11e7ef6567fa964e]
-reverse link Text to Audio--><g id="link_Text_Audio"><path d="M446.5,707.74 C446.5,707.74 446.5,844.82 446.5,844.82 " fill="none" id="Text-backto-Audio" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="446.5,694.74,442.5,700.74,446.5,706.74,450.5,700.74,446.5,694.74" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="374.5,768.9353,377.4389,759.8902,371.5611,759.8902,374.5,768.9353" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="54" x="387.5" y="768.8484">contains</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="418.8203" y="829.8897">0..*</text></g><!--MD5=[5b9412c1b3fe28cabf79f3eab2fda194]
-link MixingInstruction to Text--><g id="link_MixingInstruction_Text"><path d="M209,442.34 C209,525.9 209,630.5 209,630.5 C209,630.5 332.63,630.5 332.63,630.5 " fill="none" id="MixingInstruction-to-Text" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="345.63,630.5,339.63,626.5,333.63,630.5,339.63,634.5,345.63,630.5" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="134.2544,581.7066,136.7651,590.8798,141.6774,587.6521,134.2544,581.7066" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="54" x="150" y="590.7984">contains</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="184.5781" y="467.9562">0..*</text></g><!--MD5=[f29d59fb2fa71b21af7d0eb83d8376ef]
-reverse link ScriptEvent to Text--><g id="link_ScriptEvent_Text"><path d="M457,469.84 C457,469.84 457,568.75 457,568.75 " fill="none" id="ScriptEvent-backto-Text" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="457,456.84,453,462.84,457,468.84,461,462.84,457,456.84" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="385,511.9553,387.9389,502.9102,382.0611,502.9102,385,511.9553" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="54" x="398" y="511.8684">contains</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="429.2656" y="553.7873">0..*</text></g><!--MD5=[4f648ea106634e58c3ed515e7784723d]
-reverse link Character to ScriptEvent--><g id="link_Character_ScriptEvent"><path d="M673.53,339.5 C673.53,339.5 599.8,339.5 599.8,339.5 " fill="none" id="Character-backto-ScriptEvent" style="stroke:#000000;stroke-width:1.0;stroke-dasharray:7.0,7.0;"/><polygon fill="#000000" points="678.53,339.5,669.53,335.5,673.53,339.5,669.53,343.5,678.53,339.5" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="646.0347" y="332.2975">0..*</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="611.9623" y="332.4641">0..*</text></g><!--MD5=[6c6f526e9744d2ca0e9ccf6ec9943001]
-link MixingInstruction to AudioRecording--><g id="link_MixingInstruction_AudioRecording"><path d="M162,442.34 C162,442.34 162,988.19 162,988.19 " fill="none" id="MixingInstruction-to-AudioRecording" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="162,1001.19,166,995.19,162,989.19,158,995.19,162,1001.19" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="90,697.9253,87.0611,706.9704,92.9389,706.9704,90,697.9253" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="54" x="103" y="707.8384">contains</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="133.8328" y="467.9562">0..*</text></g><!--MD5=[c39e3121f302de64312c2198566bc1c1]
-reverse link Audio to SynthesizedAudio--><g id="link_Audio_SynthesizedAudio"><path d="M460,940.5 C460,940.5 460,1016.68 460,1069.64 " fill="none" id="Audio-backto-SynthesizedAudio" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="431,987.7253,428.0611,996.7704,433.9389,996.7704,431,987.7253" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="11" x="444" y="997.6384">is</text></g><!--MD5=[d94768c2c104f13159e2f9742cea8b31]
-reverse link Audio to AudioRecording--><g id="link_Audio_AudioRecording"><path d="M298.5,940.5 C298.5,940.5 298.5,968.64 298.5,1002.61 " fill="none" id="Audio-backto-AudioRecording" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="269.5,954.2153,266.5611,963.2604,272.4389,963.2604,269.5,954.2153" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="11" x="282.5" y="964.1284">is</text></g><!--MD5=[cd51eea3fd126fca617dd86ac6b8e7fa]
-link SynthesizedAudio to AudioRecording--><!--MD5=[8cfde5dfa65547d71aaa804e4abda73e]
-@startuml class-diagram
-!theme plain
-!pragma ratio 1.3
-skinparam groupInheritance 2
-skinparam linetype ortho
-skinparam DefaultFontName sans-serif
-skinparam DefaultFontSize 16
-skinparam ArrowFontSize 13
-skinparam ArrowMessageAlignment direction
-skinparam Padding 4
-skinparam Nodesep 15
-skinparam Ranksep 20
-skinparam MinClassWidth 220
-
-together {
-    Class DAPTScript as "**DAPT Script**" [[#dapt-script]] {
-        Workflow Type [[[#workflow-type]]]
-        Script Type [[[#script-type]]]
-        Primary Language [[[#primary-language]]]
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="1314px" preserveAspectRatio="none" style="width:1065px;height:1314px;background:#FFFFFF;" version="1.1" viewBox="0 0 1065 1314" width="1065px" zoomAndPan="magnify"><defs/><g><!--MD5=[ba84c569c07e3989de82fef30200dade]
+  class DAPTScript--><g id="elem_DAPTScript"><rect fill="#FFFFFF" height="125.375" id="DAPTScript" rx="2.5" ry="2.5" style="stroke:#000000;stroke-width:1.0;" width="220" x="674" y="12"/><a href="#dapt-script" target="_top" xlink:actuate="onRequest" xlink:href="#dapt-script" xlink:show="new" xlink:title="#dapt-script" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-weight="bold" lengthAdjust="spacing" textLength="98" x="735" y="36.4688">DAPT Script</text></a><line style="stroke:#000000;stroke-width:1.0;" x1="675" x2="893" y1="48.8438" y2="48.8438"/><a href="#workflow-type" target="_top" xlink:actuate="onRequest" xlink:href="#workflow-type" xlink:show="new" xlink:title="#workflow-type" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="115" x="684" y="72.3125">Workflow Type</text></a><a href="#script-type" target="_top" xlink:actuate="onRequest" xlink:href="#script-type" xlink:show="new" xlink:title="#script-type" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="87" x="684" y="99.1563">Script Type</text></a><a href="#primary-language" target="_top" xlink:actuate="onRequest" xlink:href="#primary-language" xlink:show="new" xlink:title="#primary-language" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="141" x="684" y="126">Primary Language</text></a></g><!--MD5=[02a8746eb15ecbb4566dafa16ea4db73]
+  class Text--><g id="elem_Text"><rect fill="#FFFFFF" height="125.375" id="Text" rx="2.5" ry="2.5" style="stroke:#000000;stroke-width:1.0;" width="220" x="652" y="640.19"/><a href="#text" target="_top" xlink:actuate="onRequest" xlink:href="#text" xlink:show="new" xlink:title="#text" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-weight="bold" lengthAdjust="spacing" textLength="35" x="744.5" y="664.6588">Text</text></a><line style="stroke:#000000;stroke-width:1.0;" x1="653" x2="871" y1="677.0338" y2="677.0338"/><a href="#dfn-text" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-text" xlink:show="new" xlink:title="#dfn-text" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="99" x="662" y="700.5025">Text content</text></a><a href="#text-language-source" target="_top" xlink:actuate="onRequest" xlink:href="#text-language-source" xlink:show="new" xlink:title="#text-language-source" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="174" x="662" y="727.3463">Text Language Source</text></a><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="156" x="662" y="754.19">(optional) Language</text></g><!--MD5=[f84229a7658f804a248f87f24502d86f]
+  class Style--><g id="elem_Style"><rect fill="#FFFFFF" height="125.375" id="Style" rx="2.5" ry="2.5" style="stroke:#000000;stroke-width:1.0;" width="253" x="315.5" y="640.19"/><text fill="#000000" font-family="sans-serif" font-size="16" font-weight="bold" lengthAdjust="spacing" textLength="38" x="423" y="664.6588">Style</text><line style="stroke:#000000;stroke-width:1.0;" x1="316.5" x2="567.5" y1="677.0338" y2="677.0338"/><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="114" x="325.5" y="700.5025">Style Identifier</text><a href="#dfn-character-identifier" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-character-identifier" xlink:show="new" xlink:title="#dfn-character-identifier" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="233" x="325.5" y="727.3463">(optional) Character Identifier</text></a><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="120" x="325.5" y="754.19">Style Attributes</text></g><!--MD5=[23a68826f062503ff688839683b99b89]
+  class ScriptEvent--><g id="elem_ScriptEvent"><rect fill="#FFFFFF" height="205.9063" id="ScriptEvent" rx="2.5" ry="2.5" style="stroke:#000000;stroke-width:1.0;" width="234" x="667" y="280.19"/><a href="#script-event" target="_top" xlink:actuate="onRequest" xlink:href="#script-event" xlink:show="new" xlink:title="#script-event" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-weight="bold" lengthAdjust="spacing" textLength="97" x="735.5" y="304.6588">Script Event</text></a><line style="stroke:#000000;stroke-width:1.0;" x1="668" x2="900" y1="317.0338" y2="317.0338"/><a href="#dfn-script-event-identifier" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-script-event-identifier" xlink:show="new" xlink:title="#dfn-script-event-identifier" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="169" x="677" y="340.5025">Script Event Identifier</text></a><a href="#dfn-begin" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-begin" xlink:show="new" xlink:title="#dfn-begin" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-style="italic" lengthAdjust="spacing" textLength="123" x="677" y="367.3463">(optional) Begin</text></a><a href="#dfn-end" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-end" xlink:show="new" xlink:title="#dfn-end" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-style="italic" lengthAdjust="spacing" textLength="109" x="677" y="394.19">(optional) End</text></a><a href="#dfn-duration" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-duration" xlink:show="new" xlink:title="#dfn-duration" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-style="italic" lengthAdjust="spacing" textLength="149" x="677" y="421.0338">(optional) Duration</text></a><a href="#dfn-script-event-type" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-script-event-type" xlink:show="new" xlink:title="#dfn-script-event-type" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="214" x="677" y="447.8775">(optional) Script Event Type</text></a><a href="#on-screen" target="_top" xlink:actuate="onRequest" xlink:href="#on-screen" xlink:show="new" xlink:title="#on-screen" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="159" x="677" y="474.7213">(optional) On Screen</text></a></g><!--MD5=[ae74f858b6042c8541bbbd2ab4b8fb5b]
+  class ScriptEventDescription--><g id="elem_ScriptEventDescription"><rect fill="#FFFFFF" height="98.5313" id="ScriptEventDescription" rx="2.5" ry="2.5" style="stroke:#000000;stroke-width:1.0;" width="232" x="352" y="333.69"/><a href="#dfn-script-event-description" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-script-event-description" xlink:show="new" xlink:title="#dfn-script-event-description" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-weight="bold" lengthAdjust="spacing" textLength="197" x="369.5" y="358.1588">Script Event Description</text></a><line style="stroke:#000000;stroke-width:1.0;" x1="353" x2="583" y1="370.5338" y2="370.5338"/><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="90" x="362" y="394.0025">Description</text><a href="#dfn-description-type" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-description-type" xlink:show="new" xlink:title="#dfn-description-type" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="212" x="362" y="420.8463">(optional) Description Type</text></a></g><!--MD5=[3eff9d4279c887ef9286477750bdaaff]
+  class Character--><g id="elem_Character"><rect fill="#FFFFFF" height="125.375" id="Character" rx="2.5" ry="2.5" style="stroke:#000000;stroke-width:1.0;" width="220" x="12" y="320.19"/><a href="#character" target="_top" xlink:actuate="onRequest" xlink:href="#character" xlink:show="new" xlink:title="#character" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-weight="bold" lengthAdjust="spacing" textLength="78" x="83" y="344.6588">Character</text></a><line style="stroke:#000000;stroke-width:1.0;" x1="13" x2="231" y1="357.0338" y2="357.0338"/><a href="#dfn-character-identifier" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-character-identifier" xlink:show="new" xlink:title="#dfn-character-identifier" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="153" x="22" y="380.5025">Character Identifier</text></a><a href="#dfn-character-name" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-character-name" xlink:show="new" xlink:title="#dfn-character-name" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="45" x="22" y="407.3463">Name</text></a><a href="#dfn-character-talent-name" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-character-talent-name" xlink:show="new" xlink:title="#dfn-character-talent-name" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="179" x="22" y="434.19">(optional) Talent Name</text></a></g><!--MD5=[4e8cc7bbb60dc5d148cf8b942067baf3]
+  class Audio--><g id="elem_Audio"><rect fill="#FFFFFF" height="36.8438" id="Audio" rx="2.5" ry="2.5" style="stroke:#000000;stroke-width:1.0;" width="220" x="560" y="917.69"/><a href="#dfn-audio" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-audio" xlink:show="new" xlink:title="#dfn-audio" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-style="italic" font-weight="bold" lengthAdjust="spacing" textLength="49" x="645.5" y="942.1588">Audio</text></a></g><polygon fill="none" points="670,954.5337,677,974.5337,663,974.5337" style="stroke:#000000;stroke-width:1.0;"/><line style="stroke:#000000;stroke-width:1.0;" x1="670" x2="670" y1="974.5337" y2="993.69"/><polygon fill="none" points="622.1681,954.5337,606.0203,968.2541,600.9886,955.1896" style="stroke:#000000;stroke-width:1.0;"/><line style="stroke:#000000;stroke-width:1.0;" x1="603.5045" x2="520.5" y1="961.7218" y2="993.69"/><line style="stroke:#000000;stroke-width:1.0;" x1="696.9904" x2="726" y1="917.69" y2="897.89"/><!--MD5=[38ea2b49036364d20569c137fcddc05c]
+  class MixingInstruction--><g id="elem_MixingInstruction"><rect fill="#FFFFFF" height="205.9063" id="MixingInstruction" rx="2.5" ry="2.5" style="stroke:#000000;stroke-width:1.0;" width="220" x="839" y="1088.19"/><a href="#dfn-mixing-instruction" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-mixing-instruction" xlink:show="new" xlink:title="#dfn-mixing-instruction" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-weight="bold" lengthAdjust="spacing" textLength="151" x="873.5" y="1112.6588">Mixing Instruction</text></a><line style="stroke:#000000;stroke-width:1.0;" x1="840" x2="1058" y1="1125.0338" y2="1125.0338"/><a href="#dfn-gain" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-gain" xlink:show="new" xlink:title="#dfn-gain" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="116" x="849" y="1148.5025">(optional) Gain</text></a><a href="#dfn-pan" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-pan" xlink:show="new" xlink:title="#dfn-pan" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="108" x="849" y="1175.3463">(optional) Pan</text></a><a href="#dfn-begin" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-begin" xlink:show="new" xlink:title="#dfn-begin" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-style="italic" lengthAdjust="spacing" textLength="123" x="849" y="1202.19">(optional) Begin</text></a><a href="#dfn-end" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-end" xlink:show="new" xlink:title="#dfn-end" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-style="italic" lengthAdjust="spacing" textLength="109" x="849" y="1229.0338">(optional) End</text></a><a href="#dfn-duration" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-duration" xlink:show="new" xlink:title="#dfn-duration" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-style="italic" lengthAdjust="spacing" textLength="149" x="849" y="1255.8775">(optional) Duration</text></a><a href="#dfn-fill" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-fill" xlink:show="new" xlink:title="#dfn-fill" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="104" x="849" y="1282.7213">(optional) Fill</text></a></g><!--MD5=[94905989464663cf33e46e868b4be784]
+  class SynthesizedAudio--><g id="elem_SynthesizedAudio"><rect fill="#FFFFFF" height="98.5313" id="SynthesizedAudio" rx="2.5" ry="2.5" style="stroke:#000000;stroke-width:1.0;" width="220" x="305" y="1141.42"/><a href="#dfn-synthesized-audio" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-synthesized-audio" xlink:show="new" xlink:title="#dfn-synthesized-audio" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-weight="bold" lengthAdjust="spacing" textLength="152" x="339" y="1165.8888">Synthesized Audio</text></a><line style="stroke:#000000;stroke-width:1.0;" x1="306" x2="524" y1="1178.2638" y2="1178.2638"/><a href="#dfn-rate" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-rate" xlink:show="new" xlink:title="#dfn-rate" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="34" x="315" y="1201.7325">Rate</text></a><a href="#dfn-pitch" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-pitch" xlink:show="new" xlink:title="#dfn-pitch" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="118" x="315" y="1228.5763">(optional) Pitch</text></a></g><!--MD5=[dc7ce40dd9d22a10246a6e3b01b316d1]
+  class AudioRecording--><g id="elem_AudioRecording"><rect fill="#FFFFFF" height="232.75" id="AudioRecording" rx="2.5" ry="2.5" style="stroke:#000000;stroke-width:1.0;" width="220" x="560" y="1074.31"/><a href="#dfn-audio-recording" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-audio-recording" xlink:show="new" xlink:title="#dfn-audio-recording" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-weight="bold" lengthAdjust="spacing" textLength="138" x="601" y="1098.7788">Audio Recording</text></a><line style="stroke:#000000;stroke-width:1.0;" x1="561" x2="779" y1="1111.1538" y2="1111.1538"/><a href="#dfn-source" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-source" xlink:show="new" xlink:title="#dfn-source" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="73" x="570" y="1134.6225">Source [ ]</text></a><a href="#dfn-type" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-type" xlink:show="new" xlink:title="#dfn-type" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="57" x="570" y="1161.4663">Type [ ]</text></a><a href="#dfn-begin" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-begin" xlink:show="new" xlink:title="#dfn-begin" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-style="italic" lengthAdjust="spacing" textLength="123" x="570" y="1188.31">(optional) Begin</text></a><a href="#dfn-end" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-end" xlink:show="new" xlink:title="#dfn-end" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-style="italic" lengthAdjust="spacing" textLength="109" x="570" y="1215.1538">(optional) End</text></a><a href="#dfn-duration" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-duration" xlink:show="new" xlink:title="#dfn-duration" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-style="italic" lengthAdjust="spacing" textLength="149" x="570" y="1241.9975">(optional) Duration</text></a><a href="#dfn-in-time" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-in-time" xlink:show="new" xlink:title="#dfn-in-time" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="139" x="570" y="1268.8413">(optional) In Time</text></a><a href="#dfn-out-time" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-out-time" xlink:show="new" xlink:title="#dfn-out-time" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="152" x="570" y="1295.685">(optional) Out Time</text></a></g><!--MD5=[9a69f825aa2371ff4e3b59c0d145921b]
+  reverse link DAPTScript to ScriptEvent--><g id="link_DAPTScript_ScriptEvent"><path d="M784,151.76 C784,151.76 784,280.3 784,280.3 " fill="none" id="DAPTScript-backto-ScriptEvent" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="784,138.76,780,144.76,784,150.76,788,144.76,784,138.76" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="712,208.6853,714.9389,199.6402,709.0611,199.6402,712,208.6853" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="54" x="725" y="208.5984">contains</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="752.7516" y="265.4827">0..*</text></g><!--MD5=[4212e8dcb450f4d2a7c98f17ffac9132]
+  reverse link DAPTScript to Character--><g id="link_DAPTScript_Character"><path d="M659.57,54.69 C659.57,54.69 122,54.69 122,54.69 C122,54.69 122,225.06 122,320.22 " fill="none" id="DAPTScript-backto-Character" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="672.57,54.69,666.57,50.69,660.57,54.69,666.57,58.69,672.57,54.69" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="181.5371,37.2149,190.9483,35.8441,188.3452,30.5741,181.5371,37.2149" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="54" x="199.02" y="32.2584">contains</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="4" x="249.02" y="47.5689"> </text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="94.2656" y="305.2319">0..*</text></g><!--MD5=[83a66375c1104cb9dd87977bf190b50a]
+  reverse link DAPTScript to Style--><g id="link_DAPTScript_Style"><path d="M659.77,95.69 C659.77,95.69 318.88,95.69 318.88,95.69 C318.88,95.69 318.88,485.4 318.88,640.3 " fill="none" id="DAPTScript-backto-Style" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="672.77,95.69,666.77,91.69,660.77,95.69,666.77,99.69,672.77,95.69" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="244.2272,189.4435,251.5174,183.3358,246.535,180.2172,244.2272,189.4435" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="54" x="259.88" y="190.1184">contains</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="273.5548" y="627.9777">0..*</text></g><!--MD5=[d7948a54640a664a12c969cd73131365]
+  reverse link Character to Style--><g id="link_Character_Style"><a href="#dfn-character-style" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-character-style" xlink:show="new" xlink:title="#dfn-character-style" xlink:type="simple"><path d="M128.14,458.69 C128.14,458.69 309.75,458.69 309.75,458.69 C309.75,458.69 309.75,698.89 309.75,702.65 " fill="none" id="Character-backto-Style" style="stroke:#000000;stroke-width:1.0;stroke-dasharray:7.0,7.0;"/><polygon fill="#000000" points="123.14,458.69,132.14,462.69,128.14,458.69,132.14,454.69,123.14,458.69" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="60" x="244.75" y="507.4284">Character</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="30" x="274.75" y="522.7389">Style</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="24" x="86.14" y="475.2584">0..1</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="281.6793" y="696.0556">0..*</text></a></g><!--MD5=[2713fb4f0ce800ca46dc62865f6d7616]
+  link Character to Style--><!--MD5=[f29d59fb2fa71b21af7d0eb83d8376ef]
+  reverse link ScriptEvent to Text--><g id="link_ScriptEvent_Text"><path d="M769.5,498.82 C769.5,498.82 769.5,640.58 769.5,640.58 " fill="none" id="ScriptEvent-backto-Text" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="769.5,485.82,765.5,491.82,769.5,497.82,773.5,491.82,769.5,485.82" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="697.5,562.3553,700.4389,553.3102,694.5611,553.3102,697.5,562.3553" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="54" x="710.5" y="562.2684">contains</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="742.6328" y="625.6335">0..*</text></g><!--MD5=[f594398502f34a6b884aa79a079fe2d3]
+  link ScriptEvent to Style--><g id="link_ScriptEvent_Style"><a href="#dfn-character-style" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-character-style" xlink:show="new" xlink:title="#dfn-character-style" xlink:type="simple"><path d="M783.94,485.69 C778.96,485.69 460.25,485.69 460.25,485.69 C460.25,485.69 460.25,634.22 460.25,634.22 " fill="none" id="ScriptEvent-to-Style" style="stroke:#000000;stroke-width:1.0;stroke-dasharray:7.0,7.0;"/><polygon fill="#000000" points="460.25,639.22,464.25,630.22,460.25,634.22,456.25,630.22,460.25,639.22" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="60" x="482.83" y="503.2584">Character</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="30" x="512.83" y="518.5689">Style</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="756.834" y="510.6451">0..*</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="434.6258" y="625.2319">0..*</text></a></g><!--MD5=[c02251532fce76d92ac7f88404cb141d]
+  link ScriptEventDescription to ScriptEvent--><g id="link_ScriptEventDescription_ScriptEvent"><path d="M597.87,382.69 C597.87,382.69 654.08,382.69 654.08,382.69 " fill="none" id="ScriptEventDescription-ScriptEvent" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="666.08,382.69,660.08,378.69,654.08,382.69,660.08,386.69,666.08,382.69" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="584.87,382.69,593.87,386.69,589.87,382.69,593.87,378.69,584.87,382.69" style="stroke:#000000;stroke-width:1.0;"/><line style="stroke:#000000;stroke-width:1.0;" x1="589.87" x2="597.87" y1="382.69" y2="382.69"/><polygon fill="#000000" points="586.98,395.3453,596.0251,398.2842,596.0251,392.4063,586.98,395.3453" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="54" x="604.98" y="400.2584">contains</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="595.8449" y="375.5509">0..*</text></g><!--MD5=[5c8bb9ddc3ab8286b87e4ece0377f862]
+  reverse link ScriptEvent to MixingInstruction--><g id="link_ScriptEvent_MixingInstruction"><path d="M910.5,396.84 C910.5,396.84 910.5,1088.6 910.5,1088.6 " fill="none" id="ScriptEvent-backto-MixingInstruction" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="910.5,383.84,906.5,389.84,910.5,395.84,914.5,389.84,910.5,383.84" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="915.5,735.3753,918.4389,726.3302,912.5611,726.3302,915.5,735.3753" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="54" x="928.5" y="735.2884">contains</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="880.4039" y="1073.4488">0..*</text></g><!--MD5=[0df1842c479b8ac7c242c98afbfee682]
+  link Text to Style--><g id="link_Text_Style"><a href="#dfn-character-style" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-character-style" xlink:show="new" xlink:title="#dfn-character-style" xlink:type="simple"><path d="M652.32,702.69 C652.32,702.69 574.32,702.69 574.32,702.69 " fill="none" id="Text-to-Style" style="stroke:#000000;stroke-width:1.0;stroke-dasharray:7.0,7.0;"/><polygon fill="#000000" points="569.32,702.69,578.32,706.69,574.32,702.69,578.32,698.69,569.32,702.69" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="60" x="600.82" y="720.2584">Character</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="30" x="615.82" y="735.5689">Style</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="617.9431" y="695.4835">0..*</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="580.4901" y="695.5917">0..*</text></a></g><!--MD5=[0df1842c479b8ac7c242c98afbfee682]
+  link Text to Style--><g id="link_Text_Style_other"><path d="M652.32,744.69 C652.32,744.69 574.32,744.69 574.32,744.69 " fill="none" id="Text-to-Style-1" style="stroke:#000000;stroke-width:1.0;stroke-dasharray:7.0,7.0;"/><polygon fill="#000000" points="569.32,744.69,578.32,748.69,574.32,744.69,578.32,740.69,569.32,744.69" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="35" x="595.82" y="762.2584">Other</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="30" x="598.32" y="777.5689">Style</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="617.9431" y="764.8507">0..*</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="580.4901" y="764.3495">0..*</text></g><!--MD5=[0df1842c479b8ac7c242c98afbfee682]
+  link Text to Style--><!--MD5=[a7035052add2a35a11e7ef6567fa964e]
+  reverse link Text to Audio--><g id="link_Text_Audio"><path d="M726,779.13 C726,779.13 726,897.89 726,897.89 " fill="none" id="Text-backto-Audio" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="726,766.13,722,772.13,726,778.13,730,772.13,726,766.13" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="654,831.1653,656.9389,822.1202,651.0611,822.1202,654,831.1653" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="54" x="667" y="831.0784">contains</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="702.7031" y="882.9391">0..*</text></g><!--MD5=[de0a0acf296554a4514338e0ebb21c12]
+  reverse link Text to MixingInstruction--><g id="link_Text_MixingInstruction"><path d="M860,778.99 C860,778.99 860,1088.39 860,1088.39 " fill="none" id="Text-backto-MixingInstruction" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="860,765.99,856,771.99,860,777.99,864,771.99,860,765.99" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="865,926.3453,867.9389,917.3002,862.0611,917.3002,865,926.3453" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="54" x="878" y="926.2584">contains</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="822.2156" y="1073.5793">0..*</text></g><!--MD5=[4f648ea106634e58c3ed515e7784723d]
+  reverse link Character to ScriptEvent--><g id="link_Character_ScriptEvent"><path d="M128.12,455.69 C128.12,455.69 667.29,455.69 667.29,455.69 " fill="none" id="Character-backto-ScriptEvent" style="stroke:#000000;stroke-width:1.0;stroke-dasharray:7.0,7.0;"/><polygon fill="#000000" points="123.12,455.69,132.12,459.69,128.12,455.69,132.12,451.69,123.12,455.69" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="126.12" y="472.2584">0..*</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="632.8523" y="453.1791">0..*</text></g><!--MD5=[362c69a3187110fe38e82eca801921a4]
+  reverse link AudioRecording to MixingInstruction--><g id="link_AudioRecording_MixingInstruction"><path d="M794.27,1190.69 C794.27,1190.69 839.08,1190.69 839.08,1190.69 " fill="none" id="AudioRecording-backto-MixingInstruction" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="781.27,1190.69,787.27,1194.69,793.27,1190.69,787.27,1186.69,781.27,1190.69" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="768.92,1203.3453,759.8749,1200.4063,759.8749,1206.2842,768.92,1203.3453" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="54" x="776.92" y="1208.2584">contains</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="800.9492" y="1183.5026">0..*</text></g><!--MD5=[c39e3121f302de64312c2198566bc1c1]
+  reverse link Audio to SynthesizedAudio--><g id="link_Audio_SynthesizedAudio"><path d="M520.5,993.69 C520.5,993.69 520.5,1082.62 520.5,1140.98 " fill="none" id="Audio-backto-SynthesizedAudio" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="491.5,1049.9853,488.5611,1059.0304,494.4389,1059.0304,491.5,1049.9853" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="11" x="504.5" y="1059.8984">is</text></g><!--MD5=[d94768c2c104f13159e2f9742cea8b31]
+  reverse link Audio to AudioRecording--><g id="link_Audio_AudioRecording"><path d="M670,993.69 C670,993.69 670,1031.4 670,1073.82 " fill="none" id="Audio-backto-AudioRecording" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="641,1016.4053,638.0611,1025.4504,643.9389,1025.4504,641,1016.4053" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="11" x="654" y="1026.3184">is</text></g><!--MD5=[cd51eea3fd126fca617dd86ac6b8e7fa]
+  link SynthesizedAudio to AudioRecording--><!--MD5=[ab63e884d94ff811b75b2b2bdc3c53bd]
+  @startuml class-diagram
+  !theme plain
+  !pragma ratio 1.3
+  skinparam groupInheritance 2
+  skinparam linetype ortho
+  skinparam DefaultFontName sans-serif
+  skinparam DefaultFontSize 16
+  skinparam ArrowFontSize 13
+  skinparam ArrowMessageAlignment direction
+  skinparam Padding 4
+  ' skinparam Nodesep 30
+  skinparam Ranksep 5
+  skinparam MinClassWidth 220
+  
+  ' scale 1024 width
+  
+  together {
+  
+      Class DAPTScript as "**DAPT Script**" [[#dapt-script]] {
+          Workflow Type [[[#workflow-type]]]
+          Script Type [[[#script-type]]]
+          Primary Language [[[#primary-language]]]
+      }
+  
+      together {
+          Class ScriptEvent as "**Script Event**" [[#script-event]] {
+              Script Event Identifier [[[#dfn-script-event-identifier]]]
+              {field} {abstract} (optional) Begin [[[#dfn-begin]]]
+              {field} {abstract} (optional) End [[[#dfn-end]]]
+              {field} {abstract} (optional) Duration [[[#dfn-duration]]]
+              {field} (optional) Script Event Type [[[#dfn-script-event-type]]]
+              {field} (optional) On Screen [[[#on-screen]]]
+          }
+  
+          Class ScriptEventDescription as "**Script Event Description**" [[#dfn-script-event-description]] {
+              {field} Description
+              {field} (optional) Description Type [[[#dfn-description-type]]]
+          }
+      }
+  
+      Class Text as "**Text**" [[#text]] {
+          Text content [[[#dfn-text]]]
+          Text Language Source [[[#text-language-source]]]
+          {field} (optional) Language
+          ' {field} (optional) Inline Style Attributes
+      }
+  
+      Class Style as "**Style**" {
+          Style Identifier
+          {field} (optional) Character Identifier [[[#dfn-character-identifier]]]
+          Style Attributes
+      }
+      
+  }
+  
+  Class Character as "**Character**" [[#character]] {
+      Character Identifier [[[#dfn-character-identifier]]]
+      Name [[[#dfn-character-name]]]
+      {field} (optional) Talent Name [[[#dfn-character-talent-name]]]
+  }
+  
+  'together {
+      abstract Class Audio as "**Audio**" [[#dfn-audio]] {
+      }
+  
+      class MixingInstruction as "**Mixing Instruction**" [[#dfn-mixing-instruction]] {
+          {field} (optional) Gain [[[#dfn-gain]]]
+          {field} (optional) Pan [[[#dfn-pan]]]
+          {field} {abstract} (optional) Begin [[[#dfn-begin]]]
+          {field} {abstract} (optional) End [[[#dfn-end]]]
+          {field} {abstract} (optional) Duration [[[#dfn-duration]]]
+          {field} (optional) Fill [[[#dfn-fill]]]
+      }
+  
+      Class SynthesizedAudio as "**Synthesized Audio**" [[#dfn-synthesized-audio]] {
+          Rate [[[#dfn-rate]]]
+          {field} (optional) Pitch [[[#dfn-pitch]]]
+      }
+  
+      Class AudioRecording as "**Audio Recording**" [[#dfn-audio-recording]] {
+          Source [ ] [[[#dfn-source]]]
+          Type [ ] [[[#dfn-type]]]
+          {field} {abstract} (optional) Begin [[[#dfn-begin]]]
+          {field} {abstract} (optional) End [[[#dfn-end]]]
+          {field} {abstract} (optional) Duration [[[#dfn-duration]]]
+          {field} (optional) In Time [[[#dfn-in-time]]]
+          {field} (optional) Out Time [[[#dfn-out-time]]]
+      }
+  
+  '}
+  
+  
+  ' MixingInstruction -[hidden]r-AudioRecording
+  
+  
+  DAPTScript *- - "0..* " ScriptEvent : contains >
+  DAPTScript *-[norank]- "0..*" Character : contains\r >
+  DAPTScript *-[norank]- "0..*  " Style : contains >
+  Character "0..1  " <.down "0..*" Style [[#dfn-character-style]] : Character\rStyle
+  ScriptEvent *- - "0..*" Text : contains >
+  ScriptEvent "0..*" .[norank]> "0..*" Style [[#dfn-character-style]] : Character\rStyle
+  ScriptEvent *-left> "0..*" ScriptEventDescription : contains >
+  ScriptEvent *- "0..*" MixingInstruction : contains >
+  Text "0..*" .[norank].> "0..*" Style [[#dfn-character-style]] : Character\nStyle
+  Text "0..*" ..> "0..*" Style : Other\nStyle
+  Text *- - "0..* " Audio : contains >
+  Text *- - "0..* " MixingInstruction : contains >
+  ScriptEvent "0..*" ..left> "0..*" Character
+  AudioRecording *-right- "0..* " MixingInstruction : contains >
+  Audio <|- - SynthesizedAudio : is <
+  Audio <|- - AudioRecording : is <
+  
+  SynthesizedAudio -[hidden]r- AudioRecording
+  
+  ' Hidden links to persuade the layout to look nicer
+  ' DAPTScript -[hidden]right- Style
+  Text -[hidden]right- - - Style
+  Character -[hidden]down Style
+  ' ScriptEventDescription -[hidden]- MixingInstruction
+  ' MixingInstruction -[hidden]left- Text
+  ' Text -[hidden]left- Style
+  ' AudioRecording -[hidden]right- SynthesizedAudio
+  
+  hide empty members
+  hide circle
+  @enduml
+  
+  @startuml class-diagram
+  
+  
+  
+  
+  
+  
+  
+  <style>
+    root {
+      BackgroundColor white
+      FontColor black
+      FontName Verdana
+      HyperLinkColor blue
+      LineColor black
+      LineThickness 1
+      Margin 5
     }
-
-    Class ScriptEvent as "**Script Event**" [[#script-event]] {
-        Script Event Identifier [[[#dfn-script-event-identifier]]]
-        {field} {abstract} (optional) Begin [[[#dfn-begin]]]
-        {field} {abstract} (optional) End [[[#dfn-end]]]
-        {field} {abstract} (optional) Duration [[[#dfn-duration]]]
-        {field} (optional) Script Event Type [[[#dfn-script-event-type]]]
-        {field} (optional) Script Event Description [[[#dfn-script-event-description]]]
-        {field} (optional) On Screen [[[#on-screen]]]
+    caption {
+      LineThickness 0
     }
-
-    Class Text as "**Text**" [[#text]] {
-        Text content [[[#dfn-text]]]
-        Text Language Source [[[#text-language-source]]]
-        {field} (optional) Language
-        ' {field} (optional) Inline Style Attributes
+    footer {
+      LineThickness 0
     }
-}
-
-Class Character as "**Character**" [[#character]] {
-    Character Identifier [[[#dfn-character-identifier]]]
-    Name [[[#dfn-character-name]]]
-    {field} (optional) Talent Name [[[#dfn-character-talent-name]]]
-}
-
-Class Style as "**Style**" {
-    Style Identifier
-    {field} (optional) Character Identifier [[[#dfn-character-identifier]]]
-    Style Attributes
-}
-
-together {
-    abstract Class Audio as "**Audio**" [[#dfn-audio]] {
+    header {
+      LineThickness 0
     }
-
-    Class SynthesizedAudio as "**Synthesized Audio**" [[#dfn-synthesized-audio]] {
-        Rate [[[#dfn-rate]]]
-        {field} (optional) Pitch [[[#dfn-pitch]]]
+    node {
+      MaximumWidth 300
     }
-
-    Class AudioRecording as "**Audio Recording**" [[#dfn-audio-recording]] {
-        Source [ ] [[[#dfn-source]]]
-        Type [ ] [[[#dfn-type]]]
-        {field} {abstract} (optional) Begin [[[#dfn-begin]]]
-        {field} {abstract} (optional) End [[[#dfn-end]]]
-        {field} {abstract} (optional) Duration [[[#dfn-duration]]]
-        {field} (optional) In Time [[[#dfn-in-time]]]
-        {field} (optional) Out Time [[[#dfn-out-time]]]
+    title {
+      FontSize 22
+      LineThickness 0
     }
-
-}
-
-class MixingInstruction as "**Mixing Instruction**" [[#dfn-mixing-instruction]] {
-    {field} (optional) Gain [[[#dfn-gain]]]
-    {field} (optional) Pan [[[#dfn-pan]]]
-    {field} {abstract} (optional) Begin [[[#dfn-begin]]]
-    {field} {abstract} (optional) End [[[#dfn-end]]]
-    {field} {abstract} (optional) Duration [[[#dfn-duration]]]
-    {field} (optional) Fill [[[#dfn-fill]]]
-}
-
-' MixingInstruction -[hidden]r-AudioRecording
-
-
-DAPTScript *-down- "0..* " ScriptEvent : contains >
-DAPTScript *-right- "0..*" Character : contains\r >
-DAPTScript *-right- "0..*  " Style : contains >
-Character "0..1  " <.down. "0..*" Style [[#dfn-character-style]] : Character\rStyle
-ScriptEvent "0..*" .right.> "0..*" Style [[#dfn-character-style]] : Character\rStyle
-ScriptEvent *-left- "0..*" MixingInstruction : contains >
-Text "0..*" .right.> "0..*" Style [[#dfn-character-style]] : Character\nStyle
-Text "0..*" .right.> "0..*" Style : Other\nStyle
-Text *-down- "0..* " Audio : contains >
-Text *-left- "0..* " MixingInstruction : contains >
-ScriptEvent *-down- "0..*" Text : contains >
-ScriptEvent "0..*" .left.> "0..*" Character
-AudioRecording *-left- "0..* " MixingInstruction : contains >
-Audio <|- - SynthesizedAudio : is <
-Audio <|- - AudioRecording : is <
-
-SynthesizedAudio -[hidden]r- AudioRecording
-
-' Hidden links to persuade the layout to look nicer
-DAPTScript -[hidden]right- Style
-Character -[hidden]down- Style
-' MixingInstruction -[hidden]left- Text
-' Text -[hidden]down- Audio
-' AudioRecording -[hidden]right- SynthesizedAudio
-
-hide empty members
-hide circle
-@enduml
-
-@startuml class-diagram
-
-
-
-
-
-
-
-<style>
-  root {
+  </style>
+  
+  skinparam ArrowLollipopColor black
+  skinparam BackgroundColor white
+  skinparam DefaultFontName Verdana
+  skinparam DefaultMonospacedFontName Courier
+  skinparam LifelineStrategy nosolid
+  skinparam ParticipantPadding 10
+  skinparam SequenceLifeLineBorderColor black
+  skinparam Shadowing false
+  skinparam UseBetaStyle true
+  
+  skinparam Activity {
     BackgroundColor white
+    BarColor black
+    BorderColor black
     FontColor black
     FontName Verdana
-    HyperLinkColor blue
-    LineColor black
-    LineThickness 1
-    Margin 5
   }
-  caption {
-    LineThickness 0
+  skinparam Boundary {
+    FontColor black
   }
-  footer {
-    LineThickness 0
+  skinparam Box {
+    Padding 5
   }
-  header {
-    LineThickness 0
+  skinparam CircledCharacter {
+    FontColor black
+    FontName Courier
+    Radius 9
   }
-  node {
-    MaximumWidth 300
+  skinparam Class {
+    BackgroundColor white
+    BorderColor black
+    FontColor black
+    FontName Verdana
   }
-  title {
-    FontSize 22
-    LineThickness 0
+  skinparam ClassAttribute {
+    FontColor black
+    FontName Verdana
   }
-</style>
-
-skinparam ArrowLollipopColor black
-skinparam BackgroundColor white
-skinparam DefaultFontName Verdana
-skinparam DefaultMonospacedFontName Courier
-skinparam LifelineStrategy nosolid
-skinparam ParticipantPadding 10
-skinparam SequenceLifeLineBorderColor black
-skinparam Shadowing false
-skinparam UseBetaStyle true
-
-skinparam Activity {
-  BackgroundColor white
-  BarColor black
-  BorderColor black
-  FontColor black
-  FontName Verdana
-}
-skinparam Boundary {
-  FontColor black
-}
-skinparam Box {
-  Padding 5
-}
-skinparam CircledCharacter {
-  FontColor black
-  FontName Courier
-  Radius 9
-}
-skinparam Class {
-  BackgroundColor white
-  BorderColor black
-  FontColor black
-  FontName Verdana
-}
-skinparam ClassAttribute {
-  FontColor black
-  FontName Verdana
-}
-skinparam ClassStereotype {
-  FontColor black
-  FontName Verdana
-}
-skinparam Footer {
-  FontColor black
-  FontName Verdana
-}
-skinparam Header {
-  FontColor black
-  FontName Verdana
-}
-skinparam Hyperlink {
-  Color blue
-}
-skinparam IconPackage {
-  Color black
-  BackgroundColor white
-}
-skinparam IconPrivate {
-  Color black
-  BackgroundColor white
-}
-skinparam IconProtected {
-  Color black
-  BackgroundColor white
-}
-skinparam IconPublic {
-  Color black
-  BackgroundColor white
-}
-skinparam Note {
-  FontColor black
-  FontName Verdana
-}
-skinparam Object {
-  BorderColor black
-}
-skinparam Package {
-  BorderColor black
-  FontColor black
-  FontName Verdana
-}
-skinparam State {
-  BackgroundColor white
-  BorderColor black
-}
-skinparam StereotypeA {
-  BackgroundColor white
-  BorderColor black
-}
-skinparam StereotypeC {
-  BackgroundColor white
-  BorderColor black
-}
-skinparam StereotypeE {
-  BackgroundColor white
-  BorderColor black
-}
-skinparam StereotypeI {
-  BackgroundColor white
-  BorderColor black
-}
-skinparam StereotypeN {
-  BackgroundColor white
-  BorderColor black
-}
-skinparam UseCaseStereoType {
-  FontColor black
-  FontName Verdana
-}
-!pragma ratio 1.3
-skinparam groupInheritance 2
-skinparam linetype ortho
-skinparam DefaultFontName sans-serif
-skinparam DefaultFontSize 16
-skinparam ArrowFontSize 13
-skinparam ArrowMessageAlignment direction
-skinparam Padding 4
-skinparam Nodesep 15
-skinparam Ranksep 20
-skinparam MinClassWidth 220
-
-together {
-    Class DAPTScript as "**DAPT Script**" [[#dapt-script]] {
-        Workflow Type [[[#workflow-type]]]
-        Script Type [[[#script-type]]]
-        Primary Language [[[#primary-language]]]
-    }
-
-    Class ScriptEvent as "**Script Event**" [[#script-event]] {
-        Script Event Identifier [[[#dfn-script-event-identifier]]]
-        {field} {abstract} (optional) Begin [[[#dfn-begin]]]
-        {field} {abstract} (optional) End [[[#dfn-end]]]
-        {field} {abstract} (optional) Duration [[[#dfn-duration]]]
-        {field} (optional) Script Event Type [[[#dfn-script-event-type]]]
-        {field} (optional) Script Event Description [[[#dfn-script-event-description]]]
-        {field} (optional) On Screen [[[#on-screen]]]
-    }
-
-    Class Text as "**Text**" [[#text]] {
-        Text content [[[#dfn-text]]]
-        Text Language Source [[[#text-language-source]]]
-        {field} (optional) Language
-    }
-}
-
-Class Character as "**Character**" [[#character]] {
-    Character Identifier [[[#dfn-character-identifier]]]
-    Name [[[#dfn-character-name]]]
-    {field} (optional) Talent Name [[[#dfn-character-talent-name]]]
-}
-
-Class Style as "**Style**" {
-    Style Identifier
-    {field} (optional) Character Identifier [[[#dfn-character-identifier]]]
-    Style Attributes
-}
-
-together {
-    abstract Class Audio as "**Audio**" [[#dfn-audio]] {
-    }
-
-    Class SynthesizedAudio as "**Synthesized Audio**" [[#dfn-synthesized-audio]] {
-        Rate [[[#dfn-rate]]]
-        {field} (optional) Pitch [[[#dfn-pitch]]]
-    }
-
-    Class AudioRecording as "**Audio Recording**" [[#dfn-audio-recording]] {
-        Source [ ] [[[#dfn-source]]]
-        Type [ ] [[[#dfn-type]]]
-        {field} {abstract} (optional) Begin [[[#dfn-begin]]]
-        {field} {abstract} (optional) End [[[#dfn-end]]]
-        {field} {abstract} (optional) Duration [[[#dfn-duration]]]
-        {field} (optional) In Time [[[#dfn-in-time]]]
-        {field} (optional) Out Time [[[#dfn-out-time]]]
-    }
-
-}
-
-class MixingInstruction as "**Mixing Instruction**" [[#dfn-mixing-instruction]] {
-    {field} (optional) Gain [[[#dfn-gain]]]
-    {field} (optional) Pan [[[#dfn-pan]]]
-    {field} {abstract} (optional) Begin [[[#dfn-begin]]]
-    {field} {abstract} (optional) End [[[#dfn-end]]]
-    {field} {abstract} (optional) Duration [[[#dfn-duration]]]
-    {field} (optional) Fill [[[#dfn-fill]]]
-}
-
-
-
-DAPTScript *-down- "0..* " ScriptEvent : contains >
-DAPTScript *-right- "0..*" Character : contains\r >
-DAPTScript *-right- "0..*  " Style : contains >
-Character "0..1  " <.down. "0..*" Style [[#dfn-character-style]] : Character\rStyle
-ScriptEvent "0..*" .right.> "0..*" Style [[#dfn-character-style]] : Character\rStyle
-ScriptEvent *-left- "0..*" MixingInstruction : contains >
-Text "0..*" .right.> "0..*" Style [[#dfn-character-style]] : Character\nStyle
-Text "0..*" .right.> "0..*" Style : Other\nStyle
-Text *-down- "0..* " Audio : contains >
-Text *-left- "0..* " MixingInstruction : contains >
-ScriptEvent *-down- "0..*" Text : contains >
-ScriptEvent "0..*" .left.> "0..*" Character
-AudioRecording *-left- "0..* " MixingInstruction : contains >
-Audio <|- - SynthesizedAudio : is <
-Audio <|- - AudioRecording : is <
-
-SynthesizedAudio -[hidden]r- AudioRecording
-
-DAPTScript -[hidden]right- Style
-Character -[hidden]down- Style
-
-hide empty members
-hide circle
-@enduml
-
-PlantUML version 1.2022.7(Mon Aug 22 18:01:30 BST 2022)
-(GPL source distribution)
-Java Runtime: OpenJDK Runtime Environment
-JVM: OpenJDK 64-Bit Server VM
-Default Encoding: UTF-8
-Language: en
-Country: GB
---></g></svg>
+  skinparam ClassStereotype {
+    FontColor black
+    FontName Verdana
+  }
+  skinparam Footer {
+    FontColor black
+    FontName Verdana
+  }
+  skinparam Header {
+    FontColor black
+    FontName Verdana
+  }
+  skinparam Hyperlink {
+    Color blue
+  }
+  skinparam IconPackage {
+    Color black
+    BackgroundColor white
+  }
+  skinparam IconPrivate {
+    Color black
+    BackgroundColor white
+  }
+  skinparam IconProtected {
+    Color black
+    BackgroundColor white
+  }
+  skinparam IconPublic {
+    Color black
+    BackgroundColor white
+  }
+  skinparam Note {
+    FontColor black
+    FontName Verdana
+  }
+  skinparam Object {
+    BorderColor black
+  }
+  skinparam Package {
+    BorderColor black
+    FontColor black
+    FontName Verdana
+  }
+  skinparam State {
+    BackgroundColor white
+    BorderColor black
+  }
+  skinparam StereotypeA {
+    BackgroundColor white
+    BorderColor black
+  }
+  skinparam StereotypeC {
+    BackgroundColor white
+    BorderColor black
+  }
+  skinparam StereotypeE {
+    BackgroundColor white
+    BorderColor black
+  }
+  skinparam StereotypeI {
+    BackgroundColor white
+    BorderColor black
+  }
+  skinparam StereotypeN {
+    BackgroundColor white
+    BorderColor black
+  }
+  skinparam UseCaseStereoType {
+    FontColor black
+    FontName Verdana
+  }
+  !pragma ratio 1.3
+  skinparam groupInheritance 2
+  skinparam linetype ortho
+  skinparam DefaultFontName sans-serif
+  skinparam DefaultFontSize 16
+  skinparam ArrowFontSize 13
+  skinparam ArrowMessageAlignment direction
+  skinparam Padding 4
+  skinparam Ranksep 5
+  skinparam MinClassWidth 220
+  
+  
+  together {
+  
+      Class DAPTScript as "**DAPT Script**" [[#dapt-script]] {
+          Workflow Type [[[#workflow-type]]]
+          Script Type [[[#script-type]]]
+          Primary Language [[[#primary-language]]]
+      }
+  
+      together {
+          Class ScriptEvent as "**Script Event**" [[#script-event]] {
+              Script Event Identifier [[[#dfn-script-event-identifier]]]
+              {field} {abstract} (optional) Begin [[[#dfn-begin]]]
+              {field} {abstract} (optional) End [[[#dfn-end]]]
+              {field} {abstract} (optional) Duration [[[#dfn-duration]]]
+              {field} (optional) Script Event Type [[[#dfn-script-event-type]]]
+              {field} (optional) On Screen [[[#on-screen]]]
+          }
+  
+          Class ScriptEventDescription as "**Script Event Description**" [[#dfn-script-event-description]] {
+              {field} Description
+              {field} (optional) Description Type [[[#dfn-description-type]]]
+          }
+      }
+  
+      Class Text as "**Text**" [[#text]] {
+          Text content [[[#dfn-text]]]
+          Text Language Source [[[#text-language-source]]]
+          {field} (optional) Language
+      }
+  
+      Class Style as "**Style**" {
+          Style Identifier
+          {field} (optional) Character Identifier [[[#dfn-character-identifier]]]
+          Style Attributes
+      }
+      
+  }
+  
+  Class Character as "**Character**" [[#character]] {
+      Character Identifier [[[#dfn-character-identifier]]]
+      Name [[[#dfn-character-name]]]
+      {field} (optional) Talent Name [[[#dfn-character-talent-name]]]
+  }
+  
+      abstract Class Audio as "**Audio**" [[#dfn-audio]] {
+      }
+  
+      class MixingInstruction as "**Mixing Instruction**" [[#dfn-mixing-instruction]] {
+          {field} (optional) Gain [[[#dfn-gain]]]
+          {field} (optional) Pan [[[#dfn-pan]]]
+          {field} {abstract} (optional) Begin [[[#dfn-begin]]]
+          {field} {abstract} (optional) End [[[#dfn-end]]]
+          {field} {abstract} (optional) Duration [[[#dfn-duration]]]
+          {field} (optional) Fill [[[#dfn-fill]]]
+      }
+  
+      Class SynthesizedAudio as "**Synthesized Audio**" [[#dfn-synthesized-audio]] {
+          Rate [[[#dfn-rate]]]
+          {field} (optional) Pitch [[[#dfn-pitch]]]
+      }
+  
+      Class AudioRecording as "**Audio Recording**" [[#dfn-audio-recording]] {
+          Source [ ] [[[#dfn-source]]]
+          Type [ ] [[[#dfn-type]]]
+          {field} {abstract} (optional) Begin [[[#dfn-begin]]]
+          {field} {abstract} (optional) End [[[#dfn-end]]]
+          {field} {abstract} (optional) Duration [[[#dfn-duration]]]
+          {field} (optional) In Time [[[#dfn-in-time]]]
+          {field} (optional) Out Time [[[#dfn-out-time]]]
+      }
+  
+  
+  
+  
+  
+  DAPTScript *- - "0..* " ScriptEvent : contains >
+  DAPTScript *-[norank]- "0..*" Character : contains\r >
+  DAPTScript *-[norank]- "0..*  " Style : contains >
+  Character "0..1  " <.down "0..*" Style [[#dfn-character-style]] : Character\rStyle
+  ScriptEvent *- - "0..*" Text : contains >
+  ScriptEvent "0..*" .[norank]> "0..*" Style [[#dfn-character-style]] : Character\rStyle
+  ScriptEvent *-left> "0..*" ScriptEventDescription : contains >
+  ScriptEvent *- "0..*" MixingInstruction : contains >
+  Text "0..*" .[norank].> "0..*" Style [[#dfn-character-style]] : Character\nStyle
+  Text "0..*" ..> "0..*" Style : Other\nStyle
+  Text *- - "0..* " Audio : contains >
+  Text *- - "0..* " MixingInstruction : contains >
+  ScriptEvent "0..*" ..left> "0..*" Character
+  AudioRecording *-right- "0..* " MixingInstruction : contains >
+  Audio <|- - SynthesizedAudio : is <
+  Audio <|- - AudioRecording : is <
+  
+  SynthesizedAudio -[hidden]r- AudioRecording
+  
+  Text -[hidden]right- - - Style
+  Character -[hidden]down Style
+  
+  hide empty members
+  hide circle
+  @enduml
+  
+  PlantUML version 1.2022.7(Mon Aug 22 18:01:30 BST 2022)
+  (GPL source distribution)
+  Java Runtime: OpenJDK Runtime Environment
+  JVM: OpenJDK 64-Bit Server VM
+  Default Encoding: UTF-8
+  Language: en
+  Country: GB
+  --></g></svg>

--- a/figures/class-diagram.svg
+++ b/figures/class-diagram.svg
@@ -1,423 +1,390 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="1314px" preserveAspectRatio="none" style="width:1065px;height:1314px;background:#FFFFFF;" version="1.1" viewBox="0 0 1065 1314" width="1065px" zoomAndPan="magnify"><defs/><g><!--MD5=[ba84c569c07e3989de82fef30200dade]
-  class DAPTScript--><g id="elem_DAPTScript"><rect fill="#FFFFFF" height="125.375" id="DAPTScript" rx="2.5" ry="2.5" style="stroke:#000000;stroke-width:1.0;" width="220" x="674" y="12"/><a href="#dapt-script" target="_top" xlink:actuate="onRequest" xlink:href="#dapt-script" xlink:show="new" xlink:title="#dapt-script" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-weight="bold" lengthAdjust="spacing" textLength="98" x="735" y="36.4688">DAPT Script</text></a><line style="stroke:#000000;stroke-width:1.0;" x1="675" x2="893" y1="48.8438" y2="48.8438"/><a href="#workflow-type" target="_top" xlink:actuate="onRequest" xlink:href="#workflow-type" xlink:show="new" xlink:title="#workflow-type" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="115" x="684" y="72.3125">Workflow Type</text></a><a href="#script-type" target="_top" xlink:actuate="onRequest" xlink:href="#script-type" xlink:show="new" xlink:title="#script-type" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="87" x="684" y="99.1563">Script Type</text></a><a href="#primary-language" target="_top" xlink:actuate="onRequest" xlink:href="#primary-language" xlink:show="new" xlink:title="#primary-language" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="141" x="684" y="126">Primary Language</text></a></g><!--MD5=[02a8746eb15ecbb4566dafa16ea4db73]
-  class Text--><g id="elem_Text"><rect fill="#FFFFFF" height="125.375" id="Text" rx="2.5" ry="2.5" style="stroke:#000000;stroke-width:1.0;" width="220" x="652" y="640.19"/><a href="#text" target="_top" xlink:actuate="onRequest" xlink:href="#text" xlink:show="new" xlink:title="#text" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-weight="bold" lengthAdjust="spacing" textLength="35" x="744.5" y="664.6588">Text</text></a><line style="stroke:#000000;stroke-width:1.0;" x1="653" x2="871" y1="677.0338" y2="677.0338"/><a href="#dfn-text" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-text" xlink:show="new" xlink:title="#dfn-text" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="99" x="662" y="700.5025">Text content</text></a><a href="#text-language-source" target="_top" xlink:actuate="onRequest" xlink:href="#text-language-source" xlink:show="new" xlink:title="#text-language-source" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="174" x="662" y="727.3463">Text Language Source</text></a><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="156" x="662" y="754.19">(optional) Language</text></g><!--MD5=[f84229a7658f804a248f87f24502d86f]
-  class Style--><g id="elem_Style"><rect fill="#FFFFFF" height="125.375" id="Style" rx="2.5" ry="2.5" style="stroke:#000000;stroke-width:1.0;" width="253" x="315.5" y="640.19"/><text fill="#000000" font-family="sans-serif" font-size="16" font-weight="bold" lengthAdjust="spacing" textLength="38" x="423" y="664.6588">Style</text><line style="stroke:#000000;stroke-width:1.0;" x1="316.5" x2="567.5" y1="677.0338" y2="677.0338"/><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="114" x="325.5" y="700.5025">Style Identifier</text><a href="#dfn-character-identifier" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-character-identifier" xlink:show="new" xlink:title="#dfn-character-identifier" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="233" x="325.5" y="727.3463">(optional) Character Identifier</text></a><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="120" x="325.5" y="754.19">Style Attributes</text></g><!--MD5=[23a68826f062503ff688839683b99b89]
-  class ScriptEvent--><g id="elem_ScriptEvent"><rect fill="#FFFFFF" height="205.9063" id="ScriptEvent" rx="2.5" ry="2.5" style="stroke:#000000;stroke-width:1.0;" width="234" x="667" y="280.19"/><a href="#script-event" target="_top" xlink:actuate="onRequest" xlink:href="#script-event" xlink:show="new" xlink:title="#script-event" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-weight="bold" lengthAdjust="spacing" textLength="97" x="735.5" y="304.6588">Script Event</text></a><line style="stroke:#000000;stroke-width:1.0;" x1="668" x2="900" y1="317.0338" y2="317.0338"/><a href="#dfn-script-event-identifier" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-script-event-identifier" xlink:show="new" xlink:title="#dfn-script-event-identifier" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="169" x="677" y="340.5025">Script Event Identifier</text></a><a href="#dfn-begin" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-begin" xlink:show="new" xlink:title="#dfn-begin" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-style="italic" lengthAdjust="spacing" textLength="123" x="677" y="367.3463">(optional) Begin</text></a><a href="#dfn-end" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-end" xlink:show="new" xlink:title="#dfn-end" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-style="italic" lengthAdjust="spacing" textLength="109" x="677" y="394.19">(optional) End</text></a><a href="#dfn-duration" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-duration" xlink:show="new" xlink:title="#dfn-duration" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-style="italic" lengthAdjust="spacing" textLength="149" x="677" y="421.0338">(optional) Duration</text></a><a href="#dfn-script-event-type" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-script-event-type" xlink:show="new" xlink:title="#dfn-script-event-type" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="214" x="677" y="447.8775">(optional) Script Event Type</text></a><a href="#on-screen" target="_top" xlink:actuate="onRequest" xlink:href="#on-screen" xlink:show="new" xlink:title="#on-screen" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="159" x="677" y="474.7213">(optional) On Screen</text></a></g><!--MD5=[ae74f858b6042c8541bbbd2ab4b8fb5b]
-  class ScriptEventDescription--><g id="elem_ScriptEventDescription"><rect fill="#FFFFFF" height="98.5313" id="ScriptEventDescription" rx="2.5" ry="2.5" style="stroke:#000000;stroke-width:1.0;" width="232" x="352" y="333.69"/><a href="#dfn-script-event-description" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-script-event-description" xlink:show="new" xlink:title="#dfn-script-event-description" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-weight="bold" lengthAdjust="spacing" textLength="197" x="369.5" y="358.1588">Script Event Description</text></a><line style="stroke:#000000;stroke-width:1.0;" x1="353" x2="583" y1="370.5338" y2="370.5338"/><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="90" x="362" y="394.0025">Description</text><a href="#dfn-description-type" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-description-type" xlink:show="new" xlink:title="#dfn-description-type" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="212" x="362" y="420.8463">(optional) Description Type</text></a></g><!--MD5=[3eff9d4279c887ef9286477750bdaaff]
-  class Character--><g id="elem_Character"><rect fill="#FFFFFF" height="125.375" id="Character" rx="2.5" ry="2.5" style="stroke:#000000;stroke-width:1.0;" width="220" x="12" y="320.19"/><a href="#character" target="_top" xlink:actuate="onRequest" xlink:href="#character" xlink:show="new" xlink:title="#character" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-weight="bold" lengthAdjust="spacing" textLength="78" x="83" y="344.6588">Character</text></a><line style="stroke:#000000;stroke-width:1.0;" x1="13" x2="231" y1="357.0338" y2="357.0338"/><a href="#dfn-character-identifier" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-character-identifier" xlink:show="new" xlink:title="#dfn-character-identifier" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="153" x="22" y="380.5025">Character Identifier</text></a><a href="#dfn-character-name" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-character-name" xlink:show="new" xlink:title="#dfn-character-name" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="45" x="22" y="407.3463">Name</text></a><a href="#dfn-character-talent-name" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-character-talent-name" xlink:show="new" xlink:title="#dfn-character-talent-name" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="179" x="22" y="434.19">(optional) Talent Name</text></a></g><!--MD5=[4e8cc7bbb60dc5d148cf8b942067baf3]
-  class Audio--><g id="elem_Audio"><rect fill="#FFFFFF" height="36.8438" id="Audio" rx="2.5" ry="2.5" style="stroke:#000000;stroke-width:1.0;" width="220" x="560" y="917.69"/><a href="#dfn-audio" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-audio" xlink:show="new" xlink:title="#dfn-audio" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-style="italic" font-weight="bold" lengthAdjust="spacing" textLength="49" x="645.5" y="942.1588">Audio</text></a></g><polygon fill="none" points="670,954.5337,677,974.5337,663,974.5337" style="stroke:#000000;stroke-width:1.0;"/><line style="stroke:#000000;stroke-width:1.0;" x1="670" x2="670" y1="974.5337" y2="993.69"/><polygon fill="none" points="622.1681,954.5337,606.0203,968.2541,600.9886,955.1896" style="stroke:#000000;stroke-width:1.0;"/><line style="stroke:#000000;stroke-width:1.0;" x1="603.5045" x2="520.5" y1="961.7218" y2="993.69"/><line style="stroke:#000000;stroke-width:1.0;" x1="696.9904" x2="726" y1="917.69" y2="897.89"/><!--MD5=[38ea2b49036364d20569c137fcddc05c]
-  class MixingInstruction--><g id="elem_MixingInstruction"><rect fill="#FFFFFF" height="205.9063" id="MixingInstruction" rx="2.5" ry="2.5" style="stroke:#000000;stroke-width:1.0;" width="220" x="839" y="1088.19"/><a href="#dfn-mixing-instruction" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-mixing-instruction" xlink:show="new" xlink:title="#dfn-mixing-instruction" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-weight="bold" lengthAdjust="spacing" textLength="151" x="873.5" y="1112.6588">Mixing Instruction</text></a><line style="stroke:#000000;stroke-width:1.0;" x1="840" x2="1058" y1="1125.0338" y2="1125.0338"/><a href="#dfn-gain" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-gain" xlink:show="new" xlink:title="#dfn-gain" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="116" x="849" y="1148.5025">(optional) Gain</text></a><a href="#dfn-pan" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-pan" xlink:show="new" xlink:title="#dfn-pan" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="108" x="849" y="1175.3463">(optional) Pan</text></a><a href="#dfn-begin" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-begin" xlink:show="new" xlink:title="#dfn-begin" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-style="italic" lengthAdjust="spacing" textLength="123" x="849" y="1202.19">(optional) Begin</text></a><a href="#dfn-end" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-end" xlink:show="new" xlink:title="#dfn-end" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-style="italic" lengthAdjust="spacing" textLength="109" x="849" y="1229.0338">(optional) End</text></a><a href="#dfn-duration" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-duration" xlink:show="new" xlink:title="#dfn-duration" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-style="italic" lengthAdjust="spacing" textLength="149" x="849" y="1255.8775">(optional) Duration</text></a><a href="#dfn-fill" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-fill" xlink:show="new" xlink:title="#dfn-fill" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="104" x="849" y="1282.7213">(optional) Fill</text></a></g><!--MD5=[94905989464663cf33e46e868b4be784]
-  class SynthesizedAudio--><g id="elem_SynthesizedAudio"><rect fill="#FFFFFF" height="98.5313" id="SynthesizedAudio" rx="2.5" ry="2.5" style="stroke:#000000;stroke-width:1.0;" width="220" x="305" y="1141.42"/><a href="#dfn-synthesized-audio" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-synthesized-audio" xlink:show="new" xlink:title="#dfn-synthesized-audio" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-weight="bold" lengthAdjust="spacing" textLength="152" x="339" y="1165.8888">Synthesized Audio</text></a><line style="stroke:#000000;stroke-width:1.0;" x1="306" x2="524" y1="1178.2638" y2="1178.2638"/><a href="#dfn-rate" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-rate" xlink:show="new" xlink:title="#dfn-rate" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="34" x="315" y="1201.7325">Rate</text></a><a href="#dfn-pitch" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-pitch" xlink:show="new" xlink:title="#dfn-pitch" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="118" x="315" y="1228.5763">(optional) Pitch</text></a></g><!--MD5=[dc7ce40dd9d22a10246a6e3b01b316d1]
-  class AudioRecording--><g id="elem_AudioRecording"><rect fill="#FFFFFF" height="232.75" id="AudioRecording" rx="2.5" ry="2.5" style="stroke:#000000;stroke-width:1.0;" width="220" x="560" y="1074.31"/><a href="#dfn-audio-recording" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-audio-recording" xlink:show="new" xlink:title="#dfn-audio-recording" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-weight="bold" lengthAdjust="spacing" textLength="138" x="601" y="1098.7788">Audio Recording</text></a><line style="stroke:#000000;stroke-width:1.0;" x1="561" x2="779" y1="1111.1538" y2="1111.1538"/><a href="#dfn-source" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-source" xlink:show="new" xlink:title="#dfn-source" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="73" x="570" y="1134.6225">Source [ ]</text></a><a href="#dfn-type" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-type" xlink:show="new" xlink:title="#dfn-type" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="57" x="570" y="1161.4663">Type [ ]</text></a><a href="#dfn-begin" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-begin" xlink:show="new" xlink:title="#dfn-begin" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-style="italic" lengthAdjust="spacing" textLength="123" x="570" y="1188.31">(optional) Begin</text></a><a href="#dfn-end" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-end" xlink:show="new" xlink:title="#dfn-end" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-style="italic" lengthAdjust="spacing" textLength="109" x="570" y="1215.1538">(optional) End</text></a><a href="#dfn-duration" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-duration" xlink:show="new" xlink:title="#dfn-duration" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-style="italic" lengthAdjust="spacing" textLength="149" x="570" y="1241.9975">(optional) Duration</text></a><a href="#dfn-in-time" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-in-time" xlink:show="new" xlink:title="#dfn-in-time" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="139" x="570" y="1268.8413">(optional) In Time</text></a><a href="#dfn-out-time" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-out-time" xlink:show="new" xlink:title="#dfn-out-time" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="152" x="570" y="1295.685">(optional) Out Time</text></a></g><!--MD5=[9a69f825aa2371ff4e3b59c0d145921b]
-  reverse link DAPTScript to ScriptEvent--><g id="link_DAPTScript_ScriptEvent"><path d="M784,151.76 C784,151.76 784,280.3 784,280.3 " fill="none" id="DAPTScript-backto-ScriptEvent" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="784,138.76,780,144.76,784,150.76,788,144.76,784,138.76" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="712,208.6853,714.9389,199.6402,709.0611,199.6402,712,208.6853" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="54" x="725" y="208.5984">contains</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="752.7516" y="265.4827">0..*</text></g><!--MD5=[4212e8dcb450f4d2a7c98f17ffac9132]
-  reverse link DAPTScript to Character--><g id="link_DAPTScript_Character"><path d="M659.57,54.69 C659.57,54.69 122,54.69 122,54.69 C122,54.69 122,225.06 122,320.22 " fill="none" id="DAPTScript-backto-Character" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="672.57,54.69,666.57,50.69,660.57,54.69,666.57,58.69,672.57,54.69" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="181.5371,37.2149,190.9483,35.8441,188.3452,30.5741,181.5371,37.2149" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="54" x="199.02" y="32.2584">contains</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="4" x="249.02" y="47.5689"> </text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="94.2656" y="305.2319">0..*</text></g><!--MD5=[83a66375c1104cb9dd87977bf190b50a]
-  reverse link DAPTScript to Style--><g id="link_DAPTScript_Style"><path d="M659.77,95.69 C659.77,95.69 318.88,95.69 318.88,95.69 C318.88,95.69 318.88,485.4 318.88,640.3 " fill="none" id="DAPTScript-backto-Style" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="672.77,95.69,666.77,91.69,660.77,95.69,666.77,99.69,672.77,95.69" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="244.2272,189.4435,251.5174,183.3358,246.535,180.2172,244.2272,189.4435" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="54" x="259.88" y="190.1184">contains</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="273.5548" y="627.9777">0..*</text></g><!--MD5=[d7948a54640a664a12c969cd73131365]
-  reverse link Character to Style--><g id="link_Character_Style"><a href="#dfn-character-style" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-character-style" xlink:show="new" xlink:title="#dfn-character-style" xlink:type="simple"><path d="M128.14,458.69 C128.14,458.69 309.75,458.69 309.75,458.69 C309.75,458.69 309.75,698.89 309.75,702.65 " fill="none" id="Character-backto-Style" style="stroke:#000000;stroke-width:1.0;stroke-dasharray:7.0,7.0;"/><polygon fill="#000000" points="123.14,458.69,132.14,462.69,128.14,458.69,132.14,454.69,123.14,458.69" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="60" x="244.75" y="507.4284">Character</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="30" x="274.75" y="522.7389">Style</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="24" x="86.14" y="475.2584">0..1</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="281.6793" y="696.0556">0..*</text></a></g><!--MD5=[2713fb4f0ce800ca46dc62865f6d7616]
-  link Character to Style--><!--MD5=[f29d59fb2fa71b21af7d0eb83d8376ef]
-  reverse link ScriptEvent to Text--><g id="link_ScriptEvent_Text"><path d="M769.5,498.82 C769.5,498.82 769.5,640.58 769.5,640.58 " fill="none" id="ScriptEvent-backto-Text" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="769.5,485.82,765.5,491.82,769.5,497.82,773.5,491.82,769.5,485.82" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="697.5,562.3553,700.4389,553.3102,694.5611,553.3102,697.5,562.3553" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="54" x="710.5" y="562.2684">contains</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="742.6328" y="625.6335">0..*</text></g><!--MD5=[f594398502f34a6b884aa79a079fe2d3]
-  link ScriptEvent to Style--><g id="link_ScriptEvent_Style"><a href="#dfn-character-style" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-character-style" xlink:show="new" xlink:title="#dfn-character-style" xlink:type="simple"><path d="M783.94,485.69 C778.96,485.69 460.25,485.69 460.25,485.69 C460.25,485.69 460.25,634.22 460.25,634.22 " fill="none" id="ScriptEvent-to-Style" style="stroke:#000000;stroke-width:1.0;stroke-dasharray:7.0,7.0;"/><polygon fill="#000000" points="460.25,639.22,464.25,630.22,460.25,634.22,456.25,630.22,460.25,639.22" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="60" x="482.83" y="503.2584">Character</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="30" x="512.83" y="518.5689">Style</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="756.834" y="510.6451">0..*</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="434.6258" y="625.2319">0..*</text></a></g><!--MD5=[c02251532fce76d92ac7f88404cb141d]
-  link ScriptEventDescription to ScriptEvent--><g id="link_ScriptEventDescription_ScriptEvent"><path d="M597.87,382.69 C597.87,382.69 654.08,382.69 654.08,382.69 " fill="none" id="ScriptEventDescription-ScriptEvent" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="666.08,382.69,660.08,378.69,654.08,382.69,660.08,386.69,666.08,382.69" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="584.87,382.69,593.87,386.69,589.87,382.69,593.87,378.69,584.87,382.69" style="stroke:#000000;stroke-width:1.0;"/><line style="stroke:#000000;stroke-width:1.0;" x1="589.87" x2="597.87" y1="382.69" y2="382.69"/><polygon fill="#000000" points="586.98,395.3453,596.0251,398.2842,596.0251,392.4063,586.98,395.3453" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="54" x="604.98" y="400.2584">contains</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="595.8449" y="375.5509">0..*</text></g><!--MD5=[5c8bb9ddc3ab8286b87e4ece0377f862]
-  reverse link ScriptEvent to MixingInstruction--><g id="link_ScriptEvent_MixingInstruction"><path d="M910.5,396.84 C910.5,396.84 910.5,1088.6 910.5,1088.6 " fill="none" id="ScriptEvent-backto-MixingInstruction" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="910.5,383.84,906.5,389.84,910.5,395.84,914.5,389.84,910.5,383.84" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="915.5,735.3753,918.4389,726.3302,912.5611,726.3302,915.5,735.3753" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="54" x="928.5" y="735.2884">contains</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="880.4039" y="1073.4488">0..*</text></g><!--MD5=[0df1842c479b8ac7c242c98afbfee682]
-  link Text to Style--><g id="link_Text_Style"><a href="#dfn-character-style" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-character-style" xlink:show="new" xlink:title="#dfn-character-style" xlink:type="simple"><path d="M652.32,702.69 C652.32,702.69 574.32,702.69 574.32,702.69 " fill="none" id="Text-to-Style" style="stroke:#000000;stroke-width:1.0;stroke-dasharray:7.0,7.0;"/><polygon fill="#000000" points="569.32,702.69,578.32,706.69,574.32,702.69,578.32,698.69,569.32,702.69" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="60" x="600.82" y="720.2584">Character</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="30" x="615.82" y="735.5689">Style</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="617.9431" y="695.4835">0..*</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="580.4901" y="695.5917">0..*</text></a></g><!--MD5=[0df1842c479b8ac7c242c98afbfee682]
-  link Text to Style--><g id="link_Text_Style_other"><path d="M652.32,744.69 C652.32,744.69 574.32,744.69 574.32,744.69 " fill="none" id="Text-to-Style-1" style="stroke:#000000;stroke-width:1.0;stroke-dasharray:7.0,7.0;"/><polygon fill="#000000" points="569.32,744.69,578.32,748.69,574.32,744.69,578.32,740.69,569.32,744.69" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="35" x="595.82" y="762.2584">Other</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="30" x="598.32" y="777.5689">Style</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="617.9431" y="764.8507">0..*</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="580.4901" y="764.3495">0..*</text></g><!--MD5=[0df1842c479b8ac7c242c98afbfee682]
-  link Text to Style--><!--MD5=[a7035052add2a35a11e7ef6567fa964e]
-  reverse link Text to Audio--><g id="link_Text_Audio"><path d="M726,779.13 C726,779.13 726,897.89 726,897.89 " fill="none" id="Text-backto-Audio" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="726,766.13,722,772.13,726,778.13,730,772.13,726,766.13" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="654,831.1653,656.9389,822.1202,651.0611,822.1202,654,831.1653" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="54" x="667" y="831.0784">contains</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="702.7031" y="882.9391">0..*</text></g><!--MD5=[de0a0acf296554a4514338e0ebb21c12]
-  reverse link Text to MixingInstruction--><g id="link_Text_MixingInstruction"><path d="M860,778.99 C860,778.99 860,1088.39 860,1088.39 " fill="none" id="Text-backto-MixingInstruction" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="860,765.99,856,771.99,860,777.99,864,771.99,860,765.99" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="865,926.3453,867.9389,917.3002,862.0611,917.3002,865,926.3453" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="54" x="878" y="926.2584">contains</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="822.2156" y="1073.5793">0..*</text></g><!--MD5=[4f648ea106634e58c3ed515e7784723d]
-  reverse link Character to ScriptEvent--><g id="link_Character_ScriptEvent"><path d="M128.12,455.69 C128.12,455.69 667.29,455.69 667.29,455.69 " fill="none" id="Character-backto-ScriptEvent" style="stroke:#000000;stroke-width:1.0;stroke-dasharray:7.0,7.0;"/><polygon fill="#000000" points="123.12,455.69,132.12,459.69,128.12,455.69,132.12,451.69,123.12,455.69" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="126.12" y="472.2584">0..*</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="632.8523" y="453.1791">0..*</text></g><!--MD5=[362c69a3187110fe38e82eca801921a4]
-  reverse link AudioRecording to MixingInstruction--><g id="link_AudioRecording_MixingInstruction"><path d="M794.27,1190.69 C794.27,1190.69 839.08,1190.69 839.08,1190.69 " fill="none" id="AudioRecording-backto-MixingInstruction" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="781.27,1190.69,787.27,1194.69,793.27,1190.69,787.27,1186.69,781.27,1190.69" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="768.92,1203.3453,759.8749,1200.4063,759.8749,1206.2842,768.92,1203.3453" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="54" x="776.92" y="1208.2584">contains</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22" x="800.9492" y="1183.5026">0..*</text></g><!--MD5=[c39e3121f302de64312c2198566bc1c1]
-  reverse link Audio to SynthesizedAudio--><g id="link_Audio_SynthesizedAudio"><path d="M520.5,993.69 C520.5,993.69 520.5,1082.62 520.5,1140.98 " fill="none" id="Audio-backto-SynthesizedAudio" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="491.5,1049.9853,488.5611,1059.0304,494.4389,1059.0304,491.5,1049.9853" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="11" x="504.5" y="1059.8984">is</text></g><!--MD5=[d94768c2c104f13159e2f9742cea8b31]
-  reverse link Audio to AudioRecording--><g id="link_Audio_AudioRecording"><path d="M670,993.69 C670,993.69 670,1031.4 670,1073.82 " fill="none" id="Audio-backto-AudioRecording" style="stroke:#000000;stroke-width:1.0;"/><polygon fill="#000000" points="641,1016.4053,638.0611,1025.4504,643.9389,1025.4504,641,1016.4053" style="stroke:#000000;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="11" x="654" y="1026.3184">is</text></g><!--MD5=[cd51eea3fd126fca617dd86ac6b8e7fa]
-  link SynthesizedAudio to AudioRecording--><!--MD5=[ab63e884d94ff811b75b2b2bdc3c53bd]
-  @startuml class-diagram
-  !theme plain
-  !pragma ratio 1.3
-  skinparam groupInheritance 2
-  skinparam linetype ortho
-  skinparam DefaultFontName sans-serif
-  skinparam DefaultFontSize 16
-  skinparam ArrowFontSize 13
-  skinparam ArrowMessageAlignment direction
-  skinparam Padding 4
-  ' skinparam Nodesep 30
-  skinparam Ranksep 5
-  skinparam MinClassWidth 220
-  
-  ' scale 1024 width
-  
-  together {
-  
-      Class DAPTScript as "**DAPT Script**" [[#dapt-script]] {
-          Workflow Type [[[#workflow-type]]]
-          Script Type [[[#script-type]]]
-          Primary Language [[[#primary-language]]]
-      }
-  
-      together {
-          Class ScriptEvent as "**Script Event**" [[#script-event]] {
-              Script Event Identifier [[[#dfn-script-event-identifier]]]
-              {field} {abstract} (optional) Begin [[[#dfn-begin]]]
-              {field} {abstract} (optional) End [[[#dfn-end]]]
-              {field} {abstract} (optional) Duration [[[#dfn-duration]]]
-              {field} (optional) Script Event Type [[[#dfn-script-event-type]]]
-              {field} (optional) On Screen [[[#on-screen]]]
-          }
-  
-          Class ScriptEventDescription as "**Script Event Description**" [[#dfn-script-event-description]] {
-              {field} Description
-              {field} (optional) Description Type [[[#dfn-description-type]]]
-          }
-      }
-  
-      Class Text as "**Text**" [[#text]] {
-          Text content [[[#dfn-text]]]
-          Text Language Source [[[#text-language-source]]]
-          {field} (optional) Language
-          ' {field} (optional) Inline Style Attributes
-      }
-  
-      Class Style as "**Style**" {
-          Style Identifier
-          {field} (optional) Character Identifier [[[#dfn-character-identifier]]]
-          Style Attributes
-      }
-      
-  }
-  
-  Class Character as "**Character**" [[#character]] {
-      Character Identifier [[[#dfn-character-identifier]]]
-      Name [[[#dfn-character-name]]]
-      {field} (optional) Talent Name [[[#dfn-character-talent-name]]]
-  }
-  
-  'together {
-      abstract Class Audio as "**Audio**" [[#dfn-audio]] {
-      }
-  
-      class MixingInstruction as "**Mixing Instruction**" [[#dfn-mixing-instruction]] {
-          {field} (optional) Gain [[[#dfn-gain]]]
-          {field} (optional) Pan [[[#dfn-pan]]]
-          {field} {abstract} (optional) Begin [[[#dfn-begin]]]
-          {field} {abstract} (optional) End [[[#dfn-end]]]
-          {field} {abstract} (optional) Duration [[[#dfn-duration]]]
-          {field} (optional) Fill [[[#dfn-fill]]]
-      }
-  
-      Class SynthesizedAudio as "**Synthesized Audio**" [[#dfn-synthesized-audio]] {
-          Rate [[[#dfn-rate]]]
-          {field} (optional) Pitch [[[#dfn-pitch]]]
-      }
-  
-      Class AudioRecording as "**Audio Recording**" [[#dfn-audio-recording]] {
-          Source [ ] [[[#dfn-source]]]
-          Type [ ] [[[#dfn-type]]]
-          {field} {abstract} (optional) Begin [[[#dfn-begin]]]
-          {field} {abstract} (optional) End [[[#dfn-end]]]
-          {field} {abstract} (optional) Duration [[[#dfn-duration]]]
-          {field} (optional) In Time [[[#dfn-in-time]]]
-          {field} (optional) Out Time [[[#dfn-out-time]]]
-      }
-  
-  '}
-  
-  
-  ' MixingInstruction -[hidden]r-AudioRecording
-  
-  
-  DAPTScript *- - "0..* " ScriptEvent : contains >
-  DAPTScript *-[norank]- "0..*" Character : contains\r >
-  DAPTScript *-[norank]- "0..*  " Style : contains >
-  Character "0..1  " <.down "0..*" Style [[#dfn-character-style]] : Character\rStyle
-  ScriptEvent *- - "0..*" Text : contains >
-  ScriptEvent "0..*" .[norank]> "0..*" Style [[#dfn-character-style]] : Character\rStyle
-  ScriptEvent *-left> "0..*" ScriptEventDescription : contains >
-  ScriptEvent *- "0..*" MixingInstruction : contains >
-  Text "0..*" .[norank].> "0..*" Style [[#dfn-character-style]] : Character\nStyle
-  Text "0..*" ..> "0..*" Style : Other\nStyle
-  Text *- - "0..* " Audio : contains >
-  Text *- - "0..* " MixingInstruction : contains >
-  ScriptEvent "0..*" ..left> "0..*" Character
-  AudioRecording *-right- "0..* " MixingInstruction : contains >
-  Audio <|- - SynthesizedAudio : is <
-  Audio <|- - AudioRecording : is <
-  
-  SynthesizedAudio -[hidden]r- AudioRecording
-  
-  ' Hidden links to persuade the layout to look nicer
-  ' DAPTScript -[hidden]right- Style
-  Text -[hidden]right- - - Style
-  Character -[hidden]down Style
-  ' ScriptEventDescription -[hidden]- MixingInstruction
-  ' MixingInstruction -[hidden]left- Text
-  ' Text -[hidden]left- Style
-  ' AudioRecording -[hidden]right- SynthesizedAudio
-  
-  hide empty members
-  hide circle
-  @enduml
-  
-  @startuml class-diagram
-  
-  
-  
-  
-  
-  
-  
-  <style>
-    root {
-      BackgroundColor white
-      FontColor black
-      FontName Verdana
-      HyperLinkColor blue
-      LineColor black
-      LineThickness 1
-      Margin 5
-    }
-    caption {
-      LineThickness 0
-    }
-    footer {
-      LineThickness 0
-    }
-    header {
-      LineThickness 0
-    }
-    node {
-      MaximumWidth 300
-    }
-    title {
-      FontSize 22
-      LineThickness 0
-    }
-  </style>
-  
-  skinparam ArrowLollipopColor black
-  skinparam BackgroundColor white
-  skinparam DefaultFontName Verdana
-  skinparam DefaultMonospacedFontName Courier
-  skinparam LifelineStrategy nosolid
-  skinparam ParticipantPadding 10
-  skinparam SequenceLifeLineBorderColor black
-  skinparam Shadowing false
-  skinparam UseBetaStyle true
-  
-  skinparam Activity {
-    BackgroundColor white
-    BarColor black
-    BorderColor black
-    FontColor black
-    FontName Verdana
-  }
-  skinparam Boundary {
-    FontColor black
-  }
-  skinparam Box {
-    Padding 5
-  }
-  skinparam CircledCharacter {
-    FontColor black
-    FontName Courier
-    Radius 9
-  }
-  skinparam Class {
-    BackgroundColor white
-    BorderColor black
-    FontColor black
-    FontName Verdana
-  }
-  skinparam ClassAttribute {
-    FontColor black
-    FontName Verdana
-  }
-  skinparam ClassStereotype {
-    FontColor black
-    FontName Verdana
-  }
-  skinparam Footer {
-    FontColor black
-    FontName Verdana
-  }
-  skinparam Header {
-    FontColor black
-    FontName Verdana
-  }
-  skinparam Hyperlink {
-    Color blue
-  }
-  skinparam IconPackage {
-    Color black
-    BackgroundColor white
-  }
-  skinparam IconPrivate {
-    Color black
-    BackgroundColor white
-  }
-  skinparam IconProtected {
-    Color black
-    BackgroundColor white
-  }
-  skinparam IconPublic {
-    Color black
-    BackgroundColor white
-  }
-  skinparam Note {
-    FontColor black
-    FontName Verdana
-  }
-  skinparam Object {
-    BorderColor black
-  }
-  skinparam Package {
-    BorderColor black
-    FontColor black
-    FontName Verdana
-  }
-  skinparam State {
-    BackgroundColor white
-    BorderColor black
-  }
-  skinparam StereotypeA {
-    BackgroundColor white
-    BorderColor black
-  }
-  skinparam StereotypeC {
-    BackgroundColor white
-    BorderColor black
-  }
-  skinparam StereotypeE {
-    BackgroundColor white
-    BorderColor black
-  }
-  skinparam StereotypeI {
-    BackgroundColor white
-    BorderColor black
-  }
-  skinparam StereotypeN {
-    BackgroundColor white
-    BorderColor black
-  }
-  skinparam UseCaseStereoType {
-    FontColor black
-    FontName Verdana
-  }
-  !pragma ratio 1.3
-  skinparam groupInheritance 2
-  skinparam linetype ortho
-  skinparam DefaultFontName sans-serif
-  skinparam DefaultFontSize 16
-  skinparam ArrowFontSize 13
-  skinparam ArrowMessageAlignment direction
-  skinparam Padding 4
-  skinparam Ranksep 5
-  skinparam MinClassWidth 220
-  
-  
-  together {
-  
-      Class DAPTScript as "**DAPT Script**" [[#dapt-script]] {
-          Workflow Type [[[#workflow-type]]]
-          Script Type [[[#script-type]]]
-          Primary Language [[[#primary-language]]]
-      }
-  
-      together {
-          Class ScriptEvent as "**Script Event**" [[#script-event]] {
-              Script Event Identifier [[[#dfn-script-event-identifier]]]
-              {field} {abstract} (optional) Begin [[[#dfn-begin]]]
-              {field} {abstract} (optional) End [[[#dfn-end]]]
-              {field} {abstract} (optional) Duration [[[#dfn-duration]]]
-              {field} (optional) Script Event Type [[[#dfn-script-event-type]]]
-              {field} (optional) On Screen [[[#on-screen]]]
-          }
-  
-          Class ScriptEventDescription as "**Script Event Description**" [[#dfn-script-event-description]] {
-              {field} Description
-              {field} (optional) Description Type [[[#dfn-description-type]]]
-          }
-      }
-  
-      Class Text as "**Text**" [[#text]] {
-          Text content [[[#dfn-text]]]
-          Text Language Source [[[#text-language-source]]]
-          {field} (optional) Language
-      }
-  
-      Class Style as "**Style**" {
-          Style Identifier
-          {field} (optional) Character Identifier [[[#dfn-character-identifier]]]
-          Style Attributes
-      }
-      
-  }
-  
-  Class Character as "**Character**" [[#character]] {
-      Character Identifier [[[#dfn-character-identifier]]]
-      Name [[[#dfn-character-name]]]
-      {field} (optional) Talent Name [[[#dfn-character-talent-name]]]
-  }
-  
-      abstract Class Audio as "**Audio**" [[#dfn-audio]] {
-      }
-  
-      class MixingInstruction as "**Mixing Instruction**" [[#dfn-mixing-instruction]] {
-          {field} (optional) Gain [[[#dfn-gain]]]
-          {field} (optional) Pan [[[#dfn-pan]]]
-          {field} {abstract} (optional) Begin [[[#dfn-begin]]]
-          {field} {abstract} (optional) End [[[#dfn-end]]]
-          {field} {abstract} (optional) Duration [[[#dfn-duration]]]
-          {field} (optional) Fill [[[#dfn-fill]]]
-      }
-  
-      Class SynthesizedAudio as "**Synthesized Audio**" [[#dfn-synthesized-audio]] {
-          Rate [[[#dfn-rate]]]
-          {field} (optional) Pitch [[[#dfn-pitch]]]
-      }
-  
-      Class AudioRecording as "**Audio Recording**" [[#dfn-audio-recording]] {
-          Source [ ] [[[#dfn-source]]]
-          Type [ ] [[[#dfn-type]]]
-          {field} {abstract} (optional) Begin [[[#dfn-begin]]]
-          {field} {abstract} (optional) End [[[#dfn-end]]]
-          {field} {abstract} (optional) Duration [[[#dfn-duration]]]
-          {field} (optional) In Time [[[#dfn-in-time]]]
-          {field} (optional) Out Time [[[#dfn-out-time]]]
-      }
-  
-  
-  
-  
-  
-  DAPTScript *- - "0..* " ScriptEvent : contains >
-  DAPTScript *-[norank]- "0..*" Character : contains\r >
-  DAPTScript *-[norank]- "0..*  " Style : contains >
-  Character "0..1  " <.down "0..*" Style [[#dfn-character-style]] : Character\rStyle
-  ScriptEvent *- - "0..*" Text : contains >
-  ScriptEvent "0..*" .[norank]> "0..*" Style [[#dfn-character-style]] : Character\rStyle
-  ScriptEvent *-left> "0..*" ScriptEventDescription : contains >
-  ScriptEvent *- "0..*" MixingInstruction : contains >
-  Text "0..*" .[norank].> "0..*" Style [[#dfn-character-style]] : Character\nStyle
-  Text "0..*" ..> "0..*" Style : Other\nStyle
-  Text *- - "0..* " Audio : contains >
-  Text *- - "0..* " MixingInstruction : contains >
-  ScriptEvent "0..*" ..left> "0..*" Character
-  AudioRecording *-right- "0..* " MixingInstruction : contains >
-  Audio <|- - SynthesizedAudio : is <
-  Audio <|- - AudioRecording : is <
-  
-  SynthesizedAudio -[hidden]r- AudioRecording
-  
-  Text -[hidden]right- - - Style
-  Character -[hidden]down Style
-  
-  hide empty members
-  hide circle
-  @enduml
-  
-  PlantUML version 1.2022.7(Mon Aug 22 18:01:30 BST 2022)
-  (GPL source distribution)
-  Java Runtime: OpenJDK Runtime Environment
-  JVM: OpenJDK 64-Bit Server VM
-  Default Encoding: UTF-8
-  Language: en
-  Country: GB
-  --></g></svg>
+<?xml version="1.0" encoding="us-ascii" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+    height="1107px" preserveAspectRatio="none" style="width:1134px;height:1107px;background:#FFFFFF;" version="1.1"
+    viewBox="0 0 1134 1107" width="1134px" zoomAndPan="magnify">
+    <defs/>
+    <g>
+        <!--class DAPTScript-->
+        <g id="elem_DAPTScript">
+            <rect fill="#FFFFFF" height="125.375" id="DAPTScript" rx="2.5" ry="2.5"
+                style="stroke:#000000;stroke-width:1.0;" width="220" x="410" y="12"/>
+            <a href="#dapt-script" target="_top" xlink:actuate="onRequest" xlink:href="#dapt-script"
+                xlink:show="new" xlink:title="#dapt-script" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-weight="bold" lengthAdjust="spacing"
+                    textLength="98" x="471" y="36.4688">DAPT Script</text></a>
+                <line style="stroke:#000000;stroke-width:1.0;" x1="411" x2="629" y1="48.8438" y2="48.8438"/>
+                <a href="#workflow-type" target="_top" xlink:actuate="onRequest"
+                    xlink:href="#workflow-type" xlink:show="new" xlink:title="#workflow-type" xlink:type="simple"><text
+                        fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="115"
+                        x="420" y="72.3125">Workflow Type</text></a>
+                <a href="#script-type" target="_top" xlink:actuate="onRequest"
+                    xlink:href="#script-type" xlink:show="new" xlink:title="#script-type" xlink:type="simple"><text
+                        fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="87"
+                        x="420" y="99.1563">Script Type</text></a>
+                <a href="#primary-language" target="_top" xlink:actuate="onRequest"
+                    xlink:href="#primary-language" xlink:show="new" xlink:title="#primary-language" xlink:type="simple"><text
+                        fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing"
+                        textLength="141" x="420" y="126">Primary Language</text></a>
+        </g>
+        <!--class Character-->
+        <g id="elem_Character">
+            <rect fill="#FFFFFF" height="125.375" id="Character" rx="2.5" ry="2.5"
+                style="stroke:#000000;stroke-width:1.0;" width="220" x="248" y="287"/>
+            <a href="#character" target="_top" xlink:actuate="onRequest" xlink:href="#character"
+                xlink:show="new" xlink:title="#character" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-weight="bold" lengthAdjust="spacing"
+                    textLength="78" x="319" y="311.4688">Character</text></a>
+            <line style="stroke:#000000;stroke-width:1.0;" x1="249" x2="467" y1="323.8438" y2="323.8438"/>
+            <a href="#dfn-character-identifier" target="_top"
+                xlink:actuate="onRequest" xlink:href="#dfn-character-identifier" xlink:show="new"
+                xlink:title="#dfn-character-identifier" xlink:type="simple"><text fill="#000000"
+                    font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="153" x="258"
+                    y="347.3125">Character Identifier</text></a>
+            <a href="#dfn-character-name" target="_top" xlink:actuate="onRequest"
+                xlink:href="#dfn-character-name" xlink:show="new" xlink:title="#dfn-character-name"
+                xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16"
+                    lengthAdjust="spacing" textLength="45" x="258" y="374.1563">Name</text></a>
+            <a href="#dfn-character-talent-name" target="_top"
+                xlink:actuate="onRequest" xlink:href="#dfn-character-talent-name" xlink:show="new"
+                xlink:title="#dfn-character-talent-name" xlink:type="simple"><text fill="#000000"
+                    font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="179" x="258" y="401"
+                    >(optional) Talent Name</text></a>
+        </g>
+        <!--class ScriptEvent-->
+        <g id="elem_ScriptEvent">
+            <rect fill="#FFFFFF" height="232.75" id="ScriptEvent" rx="2.5" ry="2.5"
+                style="stroke:#000000;stroke-width:1.0;" width="287" x="538.5" y="233.32"/>
+            <a href="#script-event" target="_top" xlink:actuate="onRequest" xlink:href="#script-event"
+                xlink:show="new" xlink:title="#script-event" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-weight="bold" lengthAdjust="spacing"
+                textLength="97" x="633.5" y="257.7888">Script Event</text></a>
+            <line style="stroke:#000000;stroke-width:1.0;" x1="539.5" x2="824.5" y1="270.1638" y2="270.1638"/>
+            <a href="#dfn-script-event-identifier" target="_top"
+                xlink:actuate="onRequest" xlink:href="#dfn-script-event-identifier" xlink:show="new"
+                xlink:title="#dfn-script-event-identifier" xlink:type="simple"><text fill="#000000"
+                    font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="169" x="548.5"
+                    y="293.6325">Script Event Identifier</text></a>
+            <a href="#dfn-begin" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-begin"
+                xlink:show="new" xlink:title="#dfn-begin" xlink:type="simple"><text fill="#000000"
+                    font-family="sans-serif" font-size="16" font-style="italic" lengthAdjust="spacing"
+                    textLength="123" x="548.5" y="320.4763">(optional) Begin</text></a>
+            <a href="#dfn-end" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-end"
+                xlink:show="new" xlink:title="#dfn-end" xlink:type="simple"><text fill="#000000"
+                    font-family="sans-serif" font-size="16" font-style="italic" lengthAdjust="spacing"
+                    textLength="109" x="548.5" y="347.32">(optional) End</text></a>
+            <a href="#dfn-duration" target="_top" xlink:actuate="onRequest"
+                xlink:href="#dfn-duration" xlink:show="new" xlink:title="#dfn-duration" xlink:type="simple"><text
+                    fill="#000000" font-family="sans-serif" font-size="16" font-style="italic"
+                    lengthAdjust="spacing" textLength="149" x="548.5" y="374.1638">(optional) Duration</text></a>
+            <a href="#dfn-script-event-type" target="_top" xlink:actuate="onRequest"
+                xlink:href="#dfn-script-event-type" xlink:show="new" xlink:title="#dfn-script-event-type"
+                xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16"
+                    lengthAdjust="spacing" textLength="214" x="548.5" y="401.0075">(optional) Script Event
+                    Type</text></a>
+            <a href="#dfn-script-event-description" target="_top"
+                xlink:actuate="onRequest" xlink:href="#dfn-script-event-description" xlink:show="new"
+                xlink:title="#dfn-script-event-description" xlink:type="simple"><text fill="#000000"
+                    font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="267" x="548.5"
+                    y="427.8513">(optional) Script Event Description</text></a>
+            <a href="#on-screen" target="_top" xlink:actuate="onRequest" xlink:href="#on-screen"
+                xlink:show="new" xlink:title="#on-screen" xlink:type="simple"><text fill="#000000"
+                    font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="159" x="548.5"
+                    y="454.695">(optional) On Screen</text></a>
+        </g>
+        <!--class ScriptEventDescription-->
+        <g id="elem_ScriptEventDescription">
+            <rect fill="#FFFFFF" height="125.375" id="ScriptEventDescription" rx="2.5" ry="2.5"
+                style="stroke:#000000;stroke-width:1.0;" width="232" x="895" y="287"/>
+            <a href="#dfn-script-event-description" target="_top"
+            xlink:actuate="onRequest" xlink:href="#dfn-script-event-description" xlink:show="new"
+            xlink:title="#dfn-script-event-description" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-weight="bold" lengthAdjust="spacing"
+                textLength="197" x="912.5" y="311.4688">Script Event Description</text></a>
+            <line style="stroke:#000000;stroke-width:1.0;" x1="896" x2="1126" y1="323.8438" y2="323.8438"/>
+            <text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="90"
+                x="905" y="347.3125">Description</text>
+            <a href="#dfn-description-type" target="_top" xlink:actuate="onRequest"
+                xlink:href="#dfn-description-type" xlink:show="new" xlink:title="#dfn-description-type"
+                xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16"
+                    lengthAdjust="spacing" textLength="212" x="905" y="374.1563">(optional) Description
+                Type</text></a>
+            <text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="156"
+                x="905" y="401">(optional) Language</text>
+        </g>
+        <!--class Text-->
+        <g id="elem_Text">
+            <rect fill="#FFFFFF" height="125.375" id="Text" rx="2.5" ry="2.5"
+                style="stroke:#000000;stroke-width:1.0;" width="220" x="551" y="604"/>
+            <a href="#text" target="_top" xlink:actuate="onRequest" xlink:href="#text" xlink:show="new"
+                xlink:title="#text" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-weight="bold" lengthAdjust="spacing"
+                textLength="35" x="643.5" y="628.4688">Text</text></a>
+            <line style="stroke:#000000;stroke-width:1.0;" x1="552" x2="770" y1="640.8438" y2="640.8438"/>
+            <a href="#dfn-text" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-text"
+                xlink:show="new" xlink:title="#dfn-text" xlink:type="simple"><text fill="#000000"
+                    font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="99" x="561"
+                    y="664.3125">Text content</text></a>
+            <a href="#text-language-source" target="_top" xlink:actuate="onRequest"
+                xlink:href="#text-language-source" xlink:show="new" xlink:title="#text-language-source"
+                xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16"
+                    lengthAdjust="spacing" textLength="174" x="561" y="691.1563">Text Language Source</text></a>
+            <text fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="156"
+                x="561" y="718">(optional) Language</text>
+        </g>
+        <!--class Audio-->
+        <a href="#dfn-audio" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-audio"
+            xlink:show="new" xlink:title="#dfn-audio" xlink:type="simple"><g id="elem_Audio">
+            <rect fill="#FFFFFF" height="36.8438" id="Audio" rx="2.5" ry="2.5"
+                style="stroke:#000000;stroke-width:1.0;" width="220" x="841" y="648.27"/>
+            <text fill="#000000" font-family="sans-serif" font-size="16" font-style="italic" font-weight="bold"
+                lengthAdjust="spacing" textLength="49" x="926.5" y="672.7388">Audio</text>
+        </g></a>
+        <!--class SynthesizedAudio-->
+        <g id="elem_SynthesizedAudio">
+            <rect fill="#FFFFFF" height="98.5313" id="SynthesizedAudio" rx="2.5" ry="2.5"
+                style="stroke:#000000;stroke-width:1.0;" width="220" x="841" y="934.43"/>
+            <a href="#dfn-synthesized-audio" target="_top" xlink:actuate="onRequest"
+                xlink:href="#dfn-synthesized-audio" xlink:show="new" xlink:title="#dfn-synthesized-audio"
+                xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-weight="bold" lengthAdjust="spacing"
+                    textLength="152" x="875" y="958.8988">Synthesized Audio</text></a>
+            <line style="stroke:#000000;stroke-width:1.0;" x1="842" x2="1060" y1="971.2738" y2="971.2738"/>
+            <a href="#dfn-rate" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-rate"
+                xlink:show="new" xlink:title="#dfn-rate" xlink:type="simple"><text fill="#000000"
+                    font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="34" x="851"
+                    y="994.7425">Rate</text></a>
+            <a href="#dfn-pitch" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-pitch"
+                xlink:show="new" xlink:title="#dfn-pitch" xlink:type="simple"><text fill="#000000"
+                    font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="118" x="851"
+                    y="1021.5863">(optional) Pitch</text></a>
+        </g>
+        <!--class AudioRecording-->
+        <g id="elem_AudioRecording">
+            <rect fill="#FFFFFF" height="232.75" id="AudioRecording" rx="2.5" ry="2.5"
+                style="stroke:#000000;stroke-width:1.0;" width="220" x="551" y="867.32"/>
+            <a href="#dfn-audio-recording" target="_top" xlink:actuate="onRequest"
+                xlink:href="#dfn-audio-recording" xlink:show="new" xlink:title="#dfn-audio-recording" xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-weight="bold" lengthAdjust="spacing"
+                textLength="138" x="592" y="891.7888">Audio Recording</text></a>
+            <line style="stroke:#000000;stroke-width:1.0;" x1="552" x2="770" y1="904.1638" y2="904.1638"/>
+            <a href="#dfn-source" target="_top" xlink:actuate="onRequest"
+                xlink:href="#dfn-source" xlink:show="new" xlink:title="#dfn-source" xlink:type="simple"><text
+                    fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="73"
+                    x="561" y="927.6325">Source [ ]</text></a>
+            <a href="#dfn-type" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-type"
+                xlink:show="new" xlink:title="#dfn-type" xlink:type="simple"><text fill="#000000"
+                    font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="57" x="561"
+                    y="954.4763">Type [ ]</text></a>
+            <a href="#dfn-begin" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-begin"
+                xlink:show="new" xlink:title="#dfn-begin" xlink:type="simple"><text fill="#000000"
+                    font-family="sans-serif" font-size="16" font-style="italic" lengthAdjust="spacing"
+                    textLength="123" x="561" y="981.32">(optional) Begin</text></a>
+            <a href="#dfn-end" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-end"
+                xlink:show="new" xlink:title="#dfn-end" xlink:type="simple"><text fill="#000000"
+                    font-family="sans-serif" font-size="16" font-style="italic" lengthAdjust="spacing"
+                    textLength="109" x="561" y="1008.1638">(optional) End</text></a>
+            <a href="#dfn-duration" target="_top" xlink:actuate="onRequest"
+                xlink:href="#dfn-duration" xlink:show="new" xlink:title="#dfn-duration" xlink:type="simple"><text
+                    fill="#000000" font-family="sans-serif" font-size="16" font-style="italic"
+                    lengthAdjust="spacing" textLength="149" x="561" y="1035.0075">(optional) Duration</text></a>
+            <a href="#dfn-in-time" target="_top" xlink:actuate="onRequest"
+                xlink:href="#dfn-in-time" xlink:show="new" xlink:title="#dfn-in-time" xlink:type="simple"><text
+                    fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="139"
+                    x="561" y="1061.8513">(optional) In Time</text></a>
+            <a href="#dfn-out-time" target="_top" xlink:actuate="onRequest"
+                xlink:href="#dfn-out-time" xlink:show="new" xlink:title="#dfn-out-time" xlink:type="simple"><text
+                    fill="#000000" font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="152"
+                    x="561" y="1088.695">(optional) Out Time</text></a>
+        </g>
+        <!--class MixingInstruction-->
+        <g id="elem_MixingInstruction">
+            <rect fill="#FFFFFF" height="205.9063" id="MixingInstruction" rx="2.5" ry="2.5"
+                style="stroke:#000000;stroke-width:1.0;" width="220" x="12" y="563.74"/>
+            <a href="#dfn-mixing-instruction" target="_top" xlink:actuate="onRequest"
+                xlink:href="#dfn-mixing-instruction" xlink:show="new" xlink:title="#dfn-mixing-instruction"
+                xlink:type="simple"><text fill="#000000" font-family="sans-serif" font-size="16" font-weight="bold" lengthAdjust="spacing"
+                    textLength="151" x="46.5" y="588.2088">Mixing Instruction</text></a>
+            <line style="stroke:#000000;stroke-width:1.0;" x1="13" x2="231" y1="600.5838" y2="600.5838"/>
+            <a href="#dfn-gain" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-gain"
+                xlink:show="new" xlink:title="#dfn-gain" xlink:type="simple"><text fill="#000000"
+                    font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="116" x="22"
+                    y="624.0525">(optional) Gain</text></a>
+            <a href="#dfn-pan" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-pan"
+                xlink:show="new" xlink:title="#dfn-pan" xlink:type="simple"><text fill="#000000"
+                    font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="108" x="22"
+                    y="650.8963">(optional) Pan</text></a>
+            <a href="#dfn-begin" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-begin"
+                xlink:show="new" xlink:title="#dfn-begin" xlink:type="simple"><text fill="#000000"
+                    font-family="sans-serif" font-size="16" font-style="italic" lengthAdjust="spacing"
+                    textLength="123" x="22" y="677.74">(optional) Begin</text></a>
+            <a href="#dfn-end" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-end"
+                xlink:show="new" xlink:title="#dfn-end" xlink:type="simple"><text fill="#000000"
+                    font-family="sans-serif" font-size="16" font-style="italic" lengthAdjust="spacing"
+                    textLength="109" x="22" y="704.5838">(optional) End</text></a>
+            <a href="#dfn-duration" target="_top" xlink:actuate="onRequest"
+                xlink:href="#dfn-duration" xlink:show="new" xlink:title="#dfn-duration" xlink:type="simple"><text
+                    fill="#000000" font-family="sans-serif" font-size="16" font-style="italic"
+                    lengthAdjust="spacing" textLength="149" x="22" y="731.4275">(optional) Duration</text></a>
+            <a href="#dfn-fill" target="_top" xlink:actuate="onRequest" xlink:href="#dfn-fill"
+                xlink:show="new" xlink:title="#dfn-fill" xlink:type="simple"><text fill="#000000"
+                    font-family="sans-serif" font-size="16" lengthAdjust="spacing" textLength="104" x="22"
+                    y="758.2713">(optional) Fill</text></a>
+        </g>
+        <!--reverse link DAPTScript to ScriptEvent-->
+        <g id="link_DAPTScript_ScriptEvent">
+            <path d="M584.25,151.78 C584.25,151.78 584.25,232.84 584.25,232.84 " fill="none"
+                id="DAPTScript-backto-ScriptEvent" style="stroke:#000000;stroke-width:1.0;"/>
+            <polygon fill="#000000" points="584.25,138.78,580.25,144.78,584.25,150.78,588.25,144.78,584.25,138.78"
+                style="stroke:#000000;stroke-width:1.0;"/>
+            <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="54"
+                x="525.25" y="161.8784">contains</text>
+            <polygon fill="#000000" points="544.75,185.2758,547.6889,176.2307,541.8111,176.2307,544.75,185.2758"
+                style="stroke:#000000;stroke-width:1.0;"/>
+            <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="4"
+                x="556.75" y="185.1889">&#160;</text>
+            <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22"
+                x="547.2574" y="218.5962">0..*</text>
+        </g>
+        <!--reverse link DAPTScript to Character-->
+        <g id="link_DAPTScript_Character">
+            <path d="M439,151.78 C439,151.78 439,286.89 439,286.89 " fill="none"
+                id="DAPTScript-backto-Character" style="stroke:#000000;stroke-width:1.0;"/>
+            <polygon fill="#000000" points="439,138.78,435,144.78,439,150.78,443,144.78,439,138.78"
+                style="stroke:#000000;stroke-width:1.0;"/>
+            <polygon fill="#000000" points="367,211.9953,369.9389,202.9502,364.0611,202.9502,367,211.9953"
+                style="stroke:#000000;stroke-width:1.0;"/>
+            <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="54" x="380"
+                y="211.9084">contains</text>
+            <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22"
+                x="420.2188" y="272.3491">0..*</text>
+        </g>
+        <!--reverse link ScriptEvent to MixingInstruction-->
+        <g id="link_ScriptEvent_MixingInstruction">
+            <path
+                d="M544.75,480.36 C544.75,480.36 544.75,577.69 544.75,577.69 C544.75,577.69 357.5,577.69 232.24,577.69 "
+                fill="none" id="ScriptEvent-backto-MixingInstruction" style="stroke:#000000;stroke-width:1.0;"/>
+            <polygon fill="#000000" points="544.75,467.36,540.75,473.36,544.75,479.36,548.75,473.36,544.75,467.36"
+                style="stroke:#000000;stroke-width:1.0;"/>
+            <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="54"
+                x="378.16" y="547.2584">contains</text>
+            <polygon fill="#000000" points="392.8862,567.1426,402.396,567.259,400.6482,561.647,392.8862,567.1426"
+                style="stroke:#000000;stroke-width:1.0;"/>
+            <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="4"
+                x="409.66" y="570.5689">&#160;</text>
+            <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22"
+                x="243.8718" y="565.1434">0..*</text>
+        </g>
+        <!--link Audio to Text-->
+        <g id="link_Audio_Text">
+            <path d="M840.54,666.69 C840.54,666.69 785.16,666.69 785.16,666.69 " fill="none"
+                id="Audio-to-Text" style="stroke:#000000;stroke-width:1.0;"/>
+            <polygon fill="#000000" points="772.16,666.69,778.16,670.69,784.16,666.69,778.16,662.69,772.16,666.69"
+                style="stroke:#000000;stroke-width:1.0;"/>
+            <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="54"
+                x="785.85" y="684.2584">contains</text>
+            <polygon fill="#000000" points="810.35,702.6558,801.3049,699.7169,801.3049,705.5947,810.35,702.6558"
+                style="stroke:#000000;stroke-width:1.0;"/>
+            <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="4"
+                x="817.35" y="707.5689">&#160;</text>
+            <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22"
+                x="803.1712" y="659.6024">0..*</text>
+        </g>
+        <!--reverse link Text to MixingInstruction-->
+        <g id="link_Text_MixingInstruction">
+            <path d="M536.62,666.69 C536.62,666.69 232.23,666.69 232.23,666.69 " fill="none"
+                id="Text-backto-MixingInstruction" style="stroke:#000000;stroke-width:1.0;"/>
+            <polygon fill="#000000" points="549.62,666.69,543.62,662.69,537.62,666.69,543.62,670.69,549.62,666.69"
+                style="stroke:#000000;stroke-width:1.0;"/>
+            <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="54"
+                x="325.43" y="636.2584">contains</text>
+            <polygon fill="#000000" points="339.93,654.6558,348.9751,657.5947,348.9751,651.7169,339.93,654.6558"
+                style="stroke:#000000;stroke-width:1.0;"/>
+            <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="4"
+                x="356.93" y="659.5689">&#160;</text>
+            <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22"
+                x="243.9831" y="659.5668">0..*</text>
+        </g>
+        <!--reverse link Character to ScriptEvent-->
+        <g id="link_Character_ScriptEvent">
+            <path d="M474.14,349.69 C474.14,349.69 538.03,349.69 538.03,349.69 " fill="none"
+                id="Character-backto-ScriptEvent" style="stroke:#000000;stroke-width:1.0;stroke-dasharray:7.0,7.0;"/>
+            <polygon fill="#000000" points="469.14,349.69,478.14,353.69,474.14,349.69,478.14,345.69,469.14,349.69"
+                style="stroke:#000000;stroke-width:1.0;"/>
+            <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22"
+                x="480.1568" y="342.5317">0..*</text>
+            <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22"
+                x="504.3299" y="342.7086">0..*</text>
+        </g>
+        <!--link ScriptEventDescription to ScriptEvent-->
+        <g id="link_ScriptEventDescription_ScriptEvent">
+            <path d="M880.54,349.69 C880.54,349.69 839.98,349.69 839.98,349.69 " fill="none"
+                id="ScriptEventDescription-ScriptEvent" style="stroke:#000000;stroke-width:1.0;"/>
+            <polygon fill="#000000" points="893.54,349.69,884.54,345.69,888.54,349.69,884.54,353.69,893.54,349.69"
+                style="stroke:#000000;stroke-width:1.0;"/>
+            <line style="stroke:#000000;stroke-width:1.0;" x1="888.54" x2="880.54" y1="349.69" y2="349.69"/>
+            <polygon fill="#000000" points="826.98,349.69,832.98,353.69,838.98,349.69,832.98,345.69,826.98,349.69"
+                style="stroke:#000000;stroke-width:1.0;"/>
+            <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="54"
+                x="833.26" y="367.2584">contains</text>
+            <polygon fill="#000000" points="857.76,385.6558,848.7149,382.7169,848.7149,388.5947,857.76,385.6558"
+                style="stroke:#000000;stroke-width:1.0;"/>
+            <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="4"
+                x="864.76" y="390.5689">&#160;</text>
+            <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22"
+                x="860.94" y="342.6026">0..*</text>
+        </g>
+        <!--reverse link ScriptEvent to Text-->
+        <g id="link_ScriptEvent_Text">
+            <path d="M661,480.38 C661,480.38 661,603.59 661,603.59 " fill="none"
+                id="ScriptEvent-backto-Text" style="stroke:#000000;stroke-width:1.0;"/>
+            <polygon fill="#000000" points="661,467.38,657,473.38,661,479.38,665,473.38,661,467.38"
+                style="stroke:#000000;stroke-width:1.0;"/>
+            <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="54" x="602"
+                y="511.5484">contains</text>
+            <polygon fill="#000000" points="621.5,534.9458,624.4389,525.9007,618.5611,525.9007,621.5,534.9458"
+                style="stroke:#000000;stroke-width:1.0;"/>
+            <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="4" x="633.5"
+                y="534.8589">&#160;</text>
+            <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22"
+                x="633.4531" y="589.4815">0..*</text>
+        </g>
+        <!--reverse link AudioRecording to MixingInstruction-->
+        <g id="link_AudioRecording_MixingInstruction">
+            <path
+                d="M661,853.03 C661,853.03 661,749.69 661,749.69 C661,749.69 390.07,749.69 232.38,749.69 " fill="none"
+                id="AudioRecording-backto-MixingInstruction" style="stroke:#000000;stroke-width:1.0;"/>
+            <polygon fill="#000000" points="661,866.03,665,860.03,661,854.03,657,860.03,661,866.03"
+                style="stroke:#000000;stroke-width:1.0;"/>
+            <polygon fill="#000000" points="421.4993,736.1734,429.6036,741.1504,430.9812,735.4363,421.4993,736.1734"
+                style="stroke:#000000;stroke-width:1.0;"/>
+            <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="54"
+                x="439.36" y="742.2584">contains</text>
+            <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="22"
+                x="244.1422" y="747.6247">0..*</text>
+        </g>
+        <!--reverse link Audio to SynthesizedAudio-->
+        <g id="link_Audio_SynthesizedAudio">
+            <path d="M987.67,706.57 C987.67,706.57 987.67,934.05 987.67,934.05 " fill="none"
+                id="Audio-backto-SynthesizedAudio" style="stroke:#000000;stroke-width:1.0;"/>
+            <polygon fill="none" points="980.67,706.57,987.67,686.57,994.67,706.57,980.67,706.57"
+                style="stroke:#000000;stroke-width:1.0;"/>
+            <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="11"
+                x="968.67" y="789.8784">is</text>
+            <polygon fill="#000000" points="966.67,803.2758,963.7311,812.3209,969.6089,812.3209,966.67,803.2758"
+                style="stroke:#000000;stroke-width:1.0;"/>
+            <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="4"
+                x="978.67" y="813.1889">&#160;</text>
+        </g>
+        <!--reverse link Audio to AudioRecording-->
+        <g id="link_Audio_AudioRecording">
+            <path
+                d="M914.33,706.52 C914.33,706.52 914.33,901.69 914.33,901.69 C914.33,901.69 839.65,901.69 771.38,901.69 "
+                fill="none" id="Audio-backto-AudioRecording" style="stroke:#000000;stroke-width:1.0;"/>
+            <polygon fill="none" points="907.33,706.52,914.33,686.52,921.33,706.52,907.33,706.52"
+                style="stroke:#000000;stroke-width:1.0;"/>
+            <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="11"
+                x="895.33" y="845.1584">is</text>
+            <polygon fill="#000000" points="896.2845,859.5221,888.5688,865.0826,893.3108,868.5558,896.2845,859.5221"
+                style="stroke:#000000;stroke-width:1.0;"/>
+            <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="4"
+                x="905.33" y="868.4689">&#160;</text>
+        </g>
+        <!--link SynthesizedAudio to AudioRecording-->
+        <!--link SynthesizedAudio to AudioRecording-->
+        <!--link MixingInstruction to Audio-->
+        <!--SRC=[tLVVRzis47xNNt5r7x8PK91cGpSKGG6tQJi3Inia0VgG-O6HQ9cmH0eajTJB-h_tI4eKAIcnkxrLy8Duzztnknyyoi_qXbOKwf8mdZoh9Iag0f9e9k15SWHgotXD9AcWaAAfbtn39TE4PnHEarvPCaxrhgOWfDw8G75ErwGfzNl1zKU2-oZ2LQhGnteQTCt-eV3YPQ1SI2dkUzKlGzK5LOeKT56oWbUKQyYPf1dovm7oakGvumNy6iW-YfmgMiDl9u7mYl2j4VuU2YyOVriIfJwpN6_WzFGaIUmQpXUNDzUPPBK6ec0sdni1ECbyFeFRs-SvgNMgh6IrWeS4yFaiv7PTYdkuCIcxHTHzAqbD4bUhbOMrdZt8UOaWbv9LHExWJyAB1hDWSRKJfcKhDE2lIQ95GR7OiYNX8dYxmGWpZL8NW5-tzBDkxSbRMs-rp37bRCtmrMoThtdgJLBcbHrVyzW-68CvYaFO0zgL-LVuITIccAJy6Mv8QGhyY0DjjP4VZBeFrQNptT_6XGksJR0LjV6sEQP658KSOgUY3WqV2RoBw87SAMr8Hy6zeGNZtjsTMHrk_8xdtfJo_733yyQUzNxZl1NiAKMK3j-XeqI4lNg8ftFgp4D6aSEy1-pn-uaRrvGwHyBwmTM-rWWPZBia9DWTy2Sf1XtKSGnSFCK_918bEF1_I7wxqJ2E-eP-wKw2UMtZqVWQyRQm30UmYRyZuL2h6EIdqBLePEOO6w2VHAcoYkzXR9wZATIIcqi7hlMkfB3GMhAxHbFLXZcUTrtxjy4lcXolE1UzVG_AISpQvo3kb1r7dmgleZpq48XXw4trke5dyrmHtPSMZzw-v5modMsyGMrMaorjMLpHJ4XxyGM1WfSEGqvbfub7NrjDMFLdSbH7rw81vB7M_16ctnAF90ik8ORXihtNrwT6nsQYqP4T5X1_cQtV1Vk2TLXoPDramJHoSWWKGHKhgqGwNkaBES7d0mbINf0-urDjHtfeJKR8xoxgVohe_opcH5ZlMLbw_1eNxRVIqKJ-qziDo_5YNyaqFbn9aWGVWlCq5_SyXTd9yV4SPj5dnoixHp7JwYyEhsEhrc8MV5prS0I7Vg8zPXDS1nlPwJnFIxhMFJ4t32BaMOViKNjzztHRDcV7aXKRVToj0-A380oVrnEmyEeRy7iY2vRwWDnW2XuQM6S9P_-sUupc_YjWZj40EDZHmvAHXw2VODXGH_27rPa_Lbi5Ma1DfMf8JW6TG4bsE3kCk1HY2vnbL3xTiwxq9aM8ivdoge3tC5y3ys48oI0GXngnI1BKKw1LhNTGqUeEGt6YZCcifDy0]-->
+    </g>
+</svg>

--- a/figures/sources/class-diagram.puml
+++ b/figures/sources/class-diagram.puml
@@ -8,25 +8,34 @@ skinparam DefaultFontSize 16
 skinparam ArrowFontSize 13
 skinparam ArrowMessageAlignment direction
 skinparam Padding 4
-skinparam Nodesep 15
-skinparam Ranksep 20
+' skinparam Nodesep 30
+skinparam Ranksep 5
 skinparam MinClassWidth 220
 
+' scale 1024 width
+
 together {
+
     Class DAPTScript as "**DAPT Script**" [[#dapt-script]] {
         Workflow Type [[[#workflow-type]]]
         Script Type [[[#script-type]]]
         Primary Language [[[#primary-language]]]
     }
 
-    Class ScriptEvent as "**Script Event**" [[#script-event]] {
-        Script Event Identifier [[[#dfn-script-event-identifier]]]
-        {field} {abstract} (optional) Begin [[[#dfn-begin]]]
-        {field} {abstract} (optional) End [[[#dfn-end]]]
-        {field} {abstract} (optional) Duration [[[#dfn-duration]]]
-        {field} (optional) Script Event Type [[[#dfn-script-event-type]]]
-        {field} (optional) Script Event Description [[[#dfn-script-event-description]]]
-        {field} (optional) On Screen [[[#on-screen]]]
+    together {
+        Class ScriptEvent as "**Script Event**" [[#script-event]] {
+            Script Event Identifier [[[#dfn-script-event-identifier]]]
+            {field} {abstract} (optional) Begin [[[#dfn-begin]]]
+            {field} {abstract} (optional) End [[[#dfn-end]]]
+            {field} {abstract} (optional) Duration [[[#dfn-duration]]]
+            {field} (optional) Script Event Type [[[#dfn-script-event-type]]]
+            {field} (optional) On Screen [[[#on-screen]]]
+        }
+
+        Class ScriptEventDescription as "**Script Event Description**" [[#dfn-script-event-description]] {
+            {field} Description
+            {field} (optional) Description Type [[[#dfn-description-type]]]
+        }
     }
 
     Class Text as "**Text**" [[#text]] {
@@ -35,6 +44,13 @@ together {
         {field} (optional) Language
         ' {field} (optional) Inline Style Attributes
     }
+
+    Class Style as "**Style**" {
+        Style Identifier
+        {field} (optional) Character Identifier [[[#dfn-character-identifier]]]
+        Style Attributes
+    }
+    
 }
 
 Class Character as "**Character**" [[#character]] {
@@ -43,14 +59,17 @@ Class Character as "**Character**" [[#character]] {
     {field} (optional) Talent Name [[[#dfn-character-talent-name]]]
 }
 
-Class Style as "**Style**" {
-    Style Identifier
-    {field} (optional) Character Identifier [[[#dfn-character-identifier]]]
-    Style Attributes
-}
-
-together {
+'together {
     abstract Class Audio as "**Audio**" [[#dfn-audio]] {
+    }
+
+    class MixingInstruction as "**Mixing Instruction**" [[#dfn-mixing-instruction]] {
+        {field} (optional) Gain [[[#dfn-gain]]]
+        {field} (optional) Pan [[[#dfn-pan]]]
+        {field} {abstract} (optional) Begin [[[#dfn-begin]]]
+        {field} {abstract} (optional) End [[[#dfn-end]]]
+        {field} {abstract} (optional) Duration [[[#dfn-duration]]]
+        {field} (optional) Fill [[[#dfn-fill]]]
     }
 
     Class SynthesizedAudio as "**Synthesized Audio**" [[#dfn-synthesized-audio]] {
@@ -68,43 +87,38 @@ together {
         {field} (optional) Out Time [[[#dfn-out-time]]]
     }
 
-}
+'}
 
-class MixingInstruction as "**Mixing Instruction**" [[#dfn-mixing-instruction]] {
-    {field} (optional) Gain [[[#dfn-gain]]]
-    {field} (optional) Pan [[[#dfn-pan]]]
-    {field} {abstract} (optional) Begin [[[#dfn-begin]]]
-    {field} {abstract} (optional) End [[[#dfn-end]]]
-    {field} {abstract} (optional) Duration [[[#dfn-duration]]]
-    {field} (optional) Fill [[[#dfn-fill]]]
-}
 
 ' MixingInstruction -[hidden]r-AudioRecording
 
 
-DAPTScript *-down- "0..* " ScriptEvent : contains >
-DAPTScript *-right- "0..*" Character : contains\r >
-DAPTScript *-right- "0..*  " Style : contains >
-Character "0..1  " <.down. "0..*" Style [[#dfn-character-style]] : Character\rStyle
-ScriptEvent "0..*" .right.> "0..*" Style [[#dfn-character-style]] : Character\rStyle
-ScriptEvent *-left- "0..*" MixingInstruction : contains >
-Text "0..*" .right.> "0..*" Style [[#dfn-character-style]] : Character\nStyle
-Text "0..*" .right.> "0..*" Style : Other\nStyle
-Text *-down- "0..* " Audio : contains >
-Text *-left- "0..* " MixingInstruction : contains >
-ScriptEvent *-down- "0..*" Text : contains >
-ScriptEvent "0..*" .left.> "0..*" Character
-AudioRecording *-left- "0..* " MixingInstruction : contains >
+DAPTScript *-- "0..* " ScriptEvent : contains >
+DAPTScript *-[norank]- "0..*" Character : contains\r >
+DAPTScript *-[norank]- "0..*  " Style : contains >
+Character "0..1  " <.down "0..*" Style [[#dfn-character-style]] : Character\rStyle
+ScriptEvent *-- "0..*" Text : contains >
+ScriptEvent "0..*" .[norank]> "0..*" Style [[#dfn-character-style]] : Character\rStyle
+ScriptEvent *-left> "0..*" ScriptEventDescription : contains >
+ScriptEvent *- "0..*" MixingInstruction : contains >
+Text "0..*" .[norank].> "0..*" Style [[#dfn-character-style]] : Character\nStyle
+Text "0..*" ..> "0..*" Style : Other\nStyle
+Text *-- "0..* " Audio : contains >
+Text *-- "0..* " MixingInstruction : contains >
+ScriptEvent "0..*" ..left> "0..*" Character
+AudioRecording *-right- "0..* " MixingInstruction : contains >
 Audio <|-- SynthesizedAudio : is <
 Audio <|-- AudioRecording : is <
 
 SynthesizedAudio -[hidden]r- AudioRecording
 
 ' Hidden links to persuade the layout to look nicer
-DAPTScript -[hidden]right- Style
-Character -[hidden]down- Style
+' DAPTScript -[hidden]right- Style
+Text -[hidden]right--- Style
+Character -[hidden]down Style
+' ScriptEventDescription -[hidden]- MixingInstruction
 ' MixingInstruction -[hidden]left- Text
-' Text -[hidden]down- Audio
+' Text -[hidden]left- Style
 ' AudioRecording -[hidden]right- SynthesizedAudio
 
 hide empty members

--- a/figures/sources/class-diagram.puml
+++ b/figures/sources/class-diagram.puml
@@ -1,41 +1,44 @@
 @startuml class-diagram
 !theme plain
-!pragma ratio 1.3
-skinparam groupInheritance 2
+!pragma ratio 1
+' skinparam groupInheritance 2
 skinparam linetype ortho
 skinparam DefaultFontName sans-serif
 skinparam DefaultFontSize 16
 skinparam ArrowFontSize 13
 skinparam ArrowMessageAlignment direction
 skinparam Padding 4
-' skinparam Nodesep 30
-skinparam Ranksep 5
+skinparam Nodesep 70
+skinparam Ranksep 80
 skinparam MinClassWidth 220
 
-' scale 1024 width
+Class DAPTScript as "**DAPT Script**" [[#dapt-script]] {
+    Workflow Type [[[#workflow-type]]]
+    Script Type [[[#script-type]]]
+    Primary Language [[[#primary-language]]]
+}
 
 together {
-
-    Class DAPTScript as "**DAPT Script**" [[#dapt-script]] {
-        Workflow Type [[[#workflow-type]]]
-        Script Type [[[#script-type]]]
-        Primary Language [[[#primary-language]]]
+    Class Character as "**Character**" [[#character]] {
+        Character Identifier [[[#dfn-character-identifier]]]
+        Name [[[#dfn-character-name]]]
+        {field} (optional) Talent Name [[[#dfn-character-talent-name]]]
     }
 
-    together {
-        Class ScriptEvent as "**Script Event**" [[#script-event]] {
-            Script Event Identifier [[[#dfn-script-event-identifier]]]
-            {field} {abstract} (optional) Begin [[[#dfn-begin]]]
-            {field} {abstract} (optional) End [[[#dfn-end]]]
-            {field} {abstract} (optional) Duration [[[#dfn-duration]]]
-            {field} (optional) Script Event Type [[[#dfn-script-event-type]]]
-            {field} (optional) On Screen [[[#on-screen]]]
-        }
+    Class ScriptEvent as "**Script Event**" [[#script-event]] {
+        Script Event Identifier [[[#dfn-script-event-identifier]]]
+        {field} {abstract} (optional) Begin [[[#dfn-begin]]]
+        {field} {abstract} (optional) End [[[#dfn-end]]]
+        {field} {abstract} (optional) Duration [[[#dfn-duration]]]
+        {field} (optional) Script Event Type [[[#dfn-script-event-type]]]
+        {field} (optional) Script Event Description [[[#dfn-script-event-description]]]
+        {field} (optional) On Screen [[[#on-screen]]]
+    }
 
-        Class ScriptEventDescription as "**Script Event Description**" [[#dfn-script-event-description]] {
-            {field} Description
-            {field} (optional) Description Type [[[#dfn-description-type]]]
-        }
+    Class ScriptEventDescription as "**Script Event Description**" [[#dfn-script-event-description]] {
+        {field} Description
+        {field} (optional) Description Type [[[#dfn-description-type]]]
+        {field} (optional) Language
     }
 
     Class Text as "**Text**" [[#text]] {
@@ -44,32 +47,10 @@ together {
         {field} (optional) Language
         ' {field} (optional) Inline Style Attributes
     }
-
-    Class Style as "**Style**" {
-        Style Identifier
-        {field} (optional) Character Identifier [[[#dfn-character-identifier]]]
-        Style Attributes
-    }
-    
 }
 
-Class Character as "**Character**" [[#character]] {
-    Character Identifier [[[#dfn-character-identifier]]]
-    Name [[[#dfn-character-name]]]
-    {field} (optional) Talent Name [[[#dfn-character-talent-name]]]
-}
-
-'together {
+together {
     abstract Class Audio as "**Audio**" [[#dfn-audio]] {
-    }
-
-    class MixingInstruction as "**Mixing Instruction**" [[#dfn-mixing-instruction]] {
-        {field} (optional) Gain [[[#dfn-gain]]]
-        {field} (optional) Pan [[[#dfn-pan]]]
-        {field} {abstract} (optional) Begin [[[#dfn-begin]]]
-        {field} {abstract} (optional) End [[[#dfn-end]]]
-        {field} {abstract} (optional) Duration [[[#dfn-duration]]]
-        {field} (optional) Fill [[[#dfn-fill]]]
     }
 
     Class SynthesizedAudio as "**Synthesized Audio**" [[#dfn-synthesized-audio]] {
@@ -87,39 +68,39 @@ Class Character as "**Character**" [[#character]] {
         {field} (optional) Out Time [[[#dfn-out-time]]]
     }
 
-'}
+}
 
+class MixingInstruction as "**Mixing Instruction**" [[#dfn-mixing-instruction]] {
+    {field} (optional) Gain [[[#dfn-gain]]]
+    {field} (optional) Pan [[[#dfn-pan]]]
+    {field} {abstract} (optional) Begin [[[#dfn-begin]]]
+    {field} {abstract} (optional) End [[[#dfn-end]]]
+    {field} {abstract} (optional) Duration [[[#dfn-duration]]]
+    {field} (optional) Fill [[[#dfn-fill]]]
+}
 
 ' MixingInstruction -[hidden]r-AudioRecording
 
 
-DAPTScript *-- "0..* " ScriptEvent : contains >
-DAPTScript *-[norank]- "0..*" Character : contains\r >
-DAPTScript *-[norank]- "0..*  " Style : contains >
-Character "0..1  " <.down "0..*" Style [[#dfn-character-style]] : Character\rStyle
-ScriptEvent *-- "0..*" Text : contains >
-ScriptEvent "0..*" .[norank]> "0..*" Style [[#dfn-character-style]] : Character\rStyle
-ScriptEvent *-left> "0..*" ScriptEventDescription : contains >
-ScriptEvent *- "0..*" MixingInstruction : contains >
-Text "0..*" .[norank].> "0..*" Style [[#dfn-character-style]] : Character\nStyle
-Text "0..*" ..> "0..*" Style : Other\nStyle
-Text *-- "0..* " Audio : contains >
-Text *-- "0..* " MixingInstruction : contains >
-ScriptEvent "0..*" ..left> "0..*" Character
-AudioRecording *-right- "0..* " MixingInstruction : contains >
-Audio <|-- SynthesizedAudio : is <
-Audio <|-- AudioRecording : is <
+DAPTScript *-down- "0..* " ScriptEvent : contains\n >
+DAPTScript *-- "0..*" Character : contains >
+ScriptEvent *-down- "0..*" MixingInstruction : contains\n >
+Text *-left- "0..* " Audio : contains\n <
+Text *-- "0..* " MixingInstruction : contains\n >
+Character "0..*" <.right. "0..*" ScriptEvent
+ScriptEvent *-left> "0..*" ScriptEventDescription : contains\n <
+ScriptEvent *-down- "0..*" Text : contains\n >
+AudioRecording *-- "0..* " MixingInstruction : contains >
+Audio <|-down- SynthesizedAudio : is\n <
+Audio <|-down- AudioRecording : is\n <
 
 SynthesizedAudio -[hidden]r- AudioRecording
 
 ' Hidden links to persuade the layout to look nicer
-' DAPTScript -[hidden]right- Style
-Text -[hidden]right--- Style
-Character -[hidden]down Style
-' ScriptEventDescription -[hidden]- MixingInstruction
 ' MixingInstruction -[hidden]left- Text
-' Text -[hidden]left- Style
-' AudioRecording -[hidden]right- SynthesizedAudio
+' Text -[hidden]down- Audio
+AudioRecording -[hidden]left- SynthesizedAudio
+Audio -[hidden]left- MixingInstruction
 
 hide empty members
 hide circle

--- a/index.html
+++ b/index.html
@@ -969,7 +969,7 @@ daptm:onScreen
           <p>The <code>&lt;ttm:desc&gt;</code> element
             MAY specify its language
             using the <code>xml:lang</code> attribute.</p>
-          <aside class="note">In the absence of a <code>xml:lang</code> attribute
+          <aside class="note">In the absence of an <code>xml:lang</code> attribute
             the language of the <a>Script Event Description</a> is inherited from the
             parent <a>Script Event</a> object.</aside>
           <pre class="example"
@@ -977,11 +977,11 @@ daptm:onScreen
             data-include-format="text">
           </pre>
           <p>Each <a>Script Event Description</a> can be annotated with
-            one or more <dfn>Description Type</dfn>s
+            one or more <dfn data-lt="Description Type">Description Types</dfn>
             to categorise further the purpose of the Script Event Description.</p>
           <p>Each <a>Description Type</a> is represented in a <a>DAPT Document</a> by
             a <code>daptm:descType</code> attribute on the <code>&lt;ttm:desc&gt;</code> element.</p>
-          <p>The <code>&lt;ttm:desc&gt;</code> element MAY have zero or one <code>daptm:descType</code> attribute.
+          <p>The <code>&lt;ttm:desc&gt;</code> element MAY have zero or one <code>daptm:descType</code> attributes.
             The <code>daptm:descType</code> attribute is defined below.
             Its possible values are as indicated in the registry at YYY.</p>
           <p class="ednote">Registry to be defined.</p>

--- a/index.html
+++ b/index.html
@@ -954,19 +954,36 @@ daptm:onScreen
         </section>
         <section>
           <h4>Script Event Description</h4>
-          <p>The <dfn>Script Event Description</dfn> object is an annotation providing a human-readable description of a <a>Script Event</a>.</p>
-          <p>The <a>Script Event Description</a> object is represented in a <a>DAPT Document</a> by a <code>&lt;ttm:desc&gt;</code> element at the <code>&lt;div&gt;</code> level.</p>
-          <p class="note">The <a>Script Event Description</a> does not need to be unique, i.e. it does not need to have a different value for each <a>Script Event</a>. 
-            For example a particular value could be re-used to identify in a human-readable way one or more <a>Script Events</a> that are intended to be processed together,
+          <p>The <dfn>Script Event Description</dfn> object is
+            an annotation providing a human-readable description of a <a>Script Event</a>.
+            Script Event Descriptions can themselves be classified with
+            a <a>Description Type</a>.</p>
+          <p>A <a>Script Event Description</a> object is represented in a <a>DAPT Document</a> by
+            a <code>&lt;ttm:desc&gt;</code> element at the <code>&lt;div&gt;</code> level.</p>
+          <p>Zero or more <code>&lt;ttm:desc&gt;</code> elements MAY be present.</p>
+          <p class="note">The <a>Script Event Description</a> does not need to be unique,
+            i.e. it does not need to have a different value for each <a>Script Event</a>. 
+            For example a particular value could be re-used to identify in a human-readable way
+            one or more <a>Script Events</a> that are intended to be processed together,
             e.g. in a batch recording.</p>
-          <p>Each <a>Script Event Description</a> can be annotated with a <dfn>Description Type</dfn> to categorise further the purpose of the Script Event Description.</p>
-          <p>The <a>Description Type</a> is represented in a <a>DAPT Document</a> by a <code>daptm:descType</code> attribute on the <code>&lt;ttm:desc&gt;</code> element.</p>
-        <pre class="example"
-          data-include="examples/event-desc.xml"
-          data-include-format="text">
-        </pre>
-          <p>The <code>&lt;ttm:desc&gt;</code> element MAY have a <code>daptm:descType</code> attribute specified to indicate the <a>Description Type</a>.
-            The <code>daptm:descType</code> attribute is defined below. Its possible values are as indicated in the registry at YYY.</p>
+          <p>The <code>&lt;ttm:desc&gt;</code> element
+            MAY specify its language
+            using the <code>xml:lang</code> attribute.</p>
+          <aside class="note">In the absence of a <code>xml:lang</code> attribute
+            the language of the <a>Script Event Description</a> is inherited from the
+            parent <a>Script Event</a> object.</aside>
+          <pre class="example"
+            data-include="examples/event-desc.xml"
+            data-include-format="text">
+          </pre>
+          <p>Each <a>Script Event Description</a> can be annotated with
+            one or more <dfn>Description Type</dfn>s
+            to categorise further the purpose of the Script Event Description.</p>
+          <p>Each <a>Description Type</a> is represented in a <a>DAPT Document</a> by
+            a <code>daptm:descType</code> attribute on the <code>&lt;ttm:desc&gt;</code> element.</p>
+          <p>The <code>&lt;ttm:desc&gt;</code> element MAY have zero or one <code>daptm:descType</code> attribute.
+            The <code>daptm:descType</code> attribute is defined below.
+            Its possible values are as indicated in the registry at YYY.</p>
           <p class="ednote">Registry to be defined.</p>
           <div class="exampleInner">
             <pre class="language-abnf">
@@ -977,16 +994,13 @@ daptm:descType : string
             data-include="examples/event-desc-descType.xml"
             data-include-format="text">
           </pre>
-          <p>Multiple <code>&lt;ttm:desc&gt;</code> elements MAY be present.
-            Amongst a sibling group of <code>&lt;ttm:desc&gt;</code> elements there are no constraints on the uniqueness of <code>daptm:descType</code>,
+          <p>Amongst a sibling group of <code>&lt;ttm:desc&gt;</code> elements
+            there are no constraints on the uniqueness of <code>daptm:descType</code>,
             however it may be useful as a distinguisher as shown in the following example.</p>
           <pre class="example"
             data-include="examples/event-desc-multiple-descType.xml"
             data-include-format="text">
           </pre>
-          <aside class="note">It is possible to label the language of the contents of a <code>&lt;ttm:desc&gt;</code> element
-            using the <code>xml:lang</code> attribute.
-          </aside>
         </section>
         <section>
           <h4>Script Event Type</h4>

--- a/index.html
+++ b/index.html
@@ -132,6 +132,9 @@ table.coldividers td + td { border-left:1px solid gray; }
     color: white;
     background-color: black;
   }
+  figure svg {
+    max-width: max-content !important;
+  }
   </style>
   </head>
   <body>

--- a/index.html
+++ b/index.html
@@ -769,7 +769,7 @@ table.coldividers td + td { border-left:1px solid gray; }
               <a>Translations</a> of the original language <a>script</a> in other languages.</p>
               <p class="note">Empty <a>Text</a> objects can be used to indicate explicitly that there is no text content.
                 It is recommended that empty <a>Text</a> objects are not used as a workflow placeholder to indicate incomplete work.</p></li>
-            <li>an optional <a>Script Event Description</a> property, as a human-readable description of the <a>Script Event</a>.</li>
+            <li>zero or more <a>Script Event Description</a> objects, each being a human-readable description of the <a>Script Event</a>.</li>
             <li>an optional <a>On Screen</a> property, which is an annotation indicating the position of the subject (e.g. a <a>character</a>) of the <a>Script Event</a></li>
             <li>Zero or more <a>Mixing Instruction</a> objects used to adjust playback of the programme audio during the <a>Script Event</a>.</li>
           </ul>
@@ -951,16 +951,19 @@ daptm:onScreen
         </section>
         <section>
           <h4>Script Event Description</h4>
-          <p>The <dfn>Script Event Description</dfn> property is an annotation providing a human-readable description of a <a>Script Event</a>.</p>
-          <p>The <a>Script Event Description</a> property is represented in a <a>DAPT Document</a> by a <code>&lt;ttm:desc&gt;</code> element at the <code>&lt;div&gt;</code> level.</p>
+          <p>The <dfn>Script Event Description</dfn> object is an annotation providing a human-readable description of a <a>Script Event</a>.</p>
+          <p>The <a>Script Event Description</a> object is represented in a <a>DAPT Document</a> by a <code>&lt;ttm:desc&gt;</code> element at the <code>&lt;div&gt;</code> level.</p>
           <p class="note">The <a>Script Event Description</a> does not need to be unique, i.e. it does not need to have a different value for each <a>Script Event</a>. 
             For example a particular value could be re-used to identify in a human-readable way one or more <a>Script Events</a> that are intended to be processed together,
             e.g. in a batch recording.</p>
+          <p>Each <a>Script Event Description</a> can be annotated with a <dfn>Description Type</dfn> to categorise further the purpose of the Script Event Description.</p>
+          <p>The <a>Description Type</a> is represented in a <a>DAPT Document</a> by a <code>daptm:descType</code> attribute on the <code>&lt;ttm:desc&gt;</code> element.</p>
         <pre class="example"
           data-include="examples/event-desc.xml"
           data-include-format="text">
         </pre>
-          <p>The <code>&lt;ttm:desc&gt;</code> element MAY have a <code>daptm:descType</code> attribute specified to indicate the type of description. The <code>daptm:descType</code> attribute is defined below. Its possible values are as indicated in the registry at YYY.</p>
+          <p>The <code>&lt;ttm:desc&gt;</code> element MAY have a <code>daptm:descType</code> attribute specified to indicate the <a>Description Type</a>.
+            The <code>daptm:descType</code> attribute is defined below. Its possible values are as indicated in the registry at YYY.</p>
           <p class="ednote">Registry to be defined.</p>
           <div class="exampleInner">
             <pre class="language-abnf">
@@ -971,11 +974,16 @@ daptm:descType : string
             data-include="examples/event-desc-descType.xml"
             data-include-format="text">
           </pre>
-          <p>Multiple <code>&lt;ttm:desc&gt;</code> elements MAY be present with different values of <code>daptm:descType</code>, as in the following example.</p>
+          <p>Multiple <code>&lt;ttm:desc&gt;</code> elements MAY be present.
+            Amongst a sibling group of <code>&lt;ttm:desc&gt;</code> elements there are no constraints on the uniqueness of <code>daptm:descType</code>,
+            however it may be useful as a distinguisher as shown in the following example.</p>
           <pre class="example"
             data-include="examples/event-desc-multiple-descType.xml"
             data-include-format="text">
           </pre>
+          <aside class="note">It is possible to label the language of the contents of a <code>&lt;ttm:desc&gt;</code> element
+            using the <code>xml:lang</code> attribute.
+          </aside>
         </section>
         <section>
           <h4>Script Event Type</h4>


### PR DESCRIPTION
Closes #174.

Clarifies the cardinality of Script Event Description.

Updates the data model diagram (in a way that is non-ideal but hard to fix automatically: it may be worth replacing the PlantUML-generated diagram with a more manually constructed one prior to final publication), and defines Description Type more explicitly.

Also clarify that there is no uniqueness constraint for `daptm:descType` and that `xml:lang` can be used to label the language of the contents of a `ttm:desc`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/pull/181.html" title="Last updated on Oct 9, 2023, 9:23 AM UTC (006c394)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/181/09b23e7...006c394.html" title="Last updated on Oct 9, 2023, 9:23 AM UTC (006c394)">Diff</a>