### PR TITLE
Fix styling of `#xmllang-audio-nonmatching` disposition

### DIFF
--- a/index.html
+++ b/index.html
@@ -2425,7 +2425,7 @@ daptm:eventType : string
           </tr>
           <tr>
             <td><a href="#xmllang-audio-nonmatching"><code>#xmlLang-audio-nonMatching</code></a></td>
-            <td><span class="required label">prohibited</span></td>
+            <td><span class="prohibited label">prohibited</span></td>
             <td>
               This is the profile expression of the prohibition of <code>xml:lang</code>
               on <code>&lt;audio&gt;</code> having a different computed value to the


### PR DESCRIPTION
Closes #189.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/pull/190.html" title="Last updated on Oct 6, 2023, 2:23 PM UTC (91974a7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/190/8bb73fb...91974a7.html" title="Last updated on Oct 6, 2023, 2:23 PM UTC (91974a7)">Diff</a>