### PR TITLE
Add inline Registry Section

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,9 +7,8 @@
     <script class="remove">
       // Rather than include the version control system (VCS) URL, use the Respec config value
       function replaceVCS(config) {
-        // If the element is an <a> already, Respec gives an error. Recreate the element as an <a> instead.
         document.querySelectorAll(".pp-vcs").forEach((element) => 
-          element.outerHTML=`<a class="${element.className}" href="${config.github.repoURL}">${element.innerHTML}</a>`);
+          element.href=config.github.repoURL)
       }
 
       var respecConfig = {
@@ -2701,7 +2700,7 @@ daptm:eventType : string
           <p>Changes to this  <a>W3C Registry</a> MUST be requested (the <dfn>change request</dfn>)
             using any one of the following options:</p>
           <ul>
-            <li>Open an issue on this document's <span class="pp-vcs">version control system</span>;</li>
+            <li>Open an issue on this document's <a class="pp-vcs" href="">version control system</a>;</li>
             <li>Send an email to the <a>TTWG</a>'s public email reflector
               <a href="mailto:public-tt@w3.org">public-tt@w3.org</a></li>
           </ul>
@@ -2717,7 +2716,7 @@ daptm:eventType : string
             <li>Any other supporting information, for example real world usage statistics;</li>
           </ul>
           <p>The proposer of the change MAY open a pull request (or equivalent) on
-            the <span class="pp-vcs">version control system</span>, with that pull request
+            the <a class="pp-vcs" href="">version control system</a>, with that pull request
             containing the proposed changes. If a pull request is opened then
             a corresponding issue MUST also be opened and
             the pull request MUST be linked to that issue.</p>
@@ -2732,7 +2731,7 @@ daptm:eventType : string
             <p>If the <a>custodian</a> is the <a>TTWG</a>:</p>
             <ul>
               <li>If the change proposer did not open a pull request
-                on the <span class="pp-vcs">version control system</span>,
+                on the <a class="pp-vcs" href="">version control system</a>,
                 then assessment is paused until a TTWG member
                 has opened such a pull request,
                 which MUST represent the requested changes
@@ -2756,7 +2755,7 @@ daptm:eventType : string
               </li>
             </ul>
             <p>An approved <a>change request</a> is enacted by merging its
-              related pull request into the <span class="pp-vcs">version control system</span>
+              related pull request into the <a class="pp-vcs" href="">version control system</a>
               and publishing the updated version of this document.</p>
           </section>
           <section id="team-change-request-assessment">
@@ -2766,7 +2765,7 @@ daptm:eventType : string
               offer a review period of at least 4 weeks,
               before assessing from the responses received
               if there is consensus amongst the respondents.</p>
-            <p>The Team MAY require a pull request on the <span class="pp-vcs">version control system</span>
+            <p>The Team MAY require a pull request on the <a class="pp-vcs" href="">version control system</a>
               to be opened as the basis of the review.
             </p>
             <p>If there is such consensus,

--- a/index.html
+++ b/index.html
@@ -184,10 +184,10 @@ table.coldividers td + td { border-left:1px solid gray; }
     left: -1.1em;
     position: relative;
   }
-  .registry-section:has(:is(h2, h3, h4, h5, h6)) {
+  .registry-section.has-header {
     margin-top: 3rem;
   }
-  .registry-section > div.header-wrapper :is(h2, h3, h4, h5, h6) {
+  .registry-section.has-header > div.header-wrapper :is(h2, h3, h4, h5, h6) {
     margin-top: 1rem;
   }
   </style>
@@ -2810,7 +2810,7 @@ daptm:eventType : string
         </section>
     </section> <!-- extensions-->
 
-  <section class="appendix registry-section">
+  <section class="appendix registry-section has-header">
     <h2>Registry Section</h2>
     <section id="registry-definition">
       <h2>Registry Definition</h2>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,13 @@
     <title>Dubbing and Audio description Profiles of TTML2</title>
     <script defer src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
     <script class="remove">
+      // Rather than include the version control system (VCS) URL, use the Respec config value
+      function replaceVCS(config) {
+        // If the element is an <a> already, Respec gives an error. Recreate the element as an <a> instead.
+        document.querySelectorAll(".pp-vcs").forEach((element) => 
+          element.outerHTML=`<a class="${element.className}" href="${config.github.repoURL}">${element.innerHTML}</a>`);
+      }
+
       var respecConfig = {
       // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
       specStatus: "ED",
@@ -49,6 +56,10 @@
             href: "https://tech.ebu.ch/publications/tech3390"
           }
       },
+
+      postProcess: [
+        replaceVCS,
+      ]
     };
     </script>
   <style>
@@ -145,6 +156,12 @@ table.coldividers td + td { border-left:1px solid gray; }
     </section>
 
     <section id="sotd" class="updateable-rec">
+      This document incorporates a <dfn data-cite="w3c-process#registry-section">registry section</dfn>
+      and defines <dfn data-cite="w3c-process#registry-table">registry tables</dfn>,
+      as defined in the [[w3c-process]] requirements for <a>w3c registries</a>.
+      Updates to the document that only change <a>registry tables</a> can be made
+      without meeting other requirements for Recommendation track updates,
+      as set out in <dfn data-cite="w3c-process#reg-table-update">Updating Registry Tables</dfn>. 
     </section>
 
     <section>
@@ -948,8 +965,7 @@ daptm:onScreen
             a <code>daptm:descType</code> attribute on the <code>&lt;ttm:desc&gt;</code> element.</p>
           <p>The <code>&lt;ttm:desc&gt;</code> element MAY have zero or one <code>daptm:descType</code> attributes.
             The <code>daptm:descType</code> attribute is defined below.
-            Its possible values are as indicated in the registry at YYY.</p>
-          <p class="ednote">Registry to be defined.</p>
+            Its possible values are as indicated in the <a>registry table</a> at <a href="#registry-table-descType"></a>.</p>
           <div class="exampleInner">
             <pre class="language-abnf">
 daptm:descType : string
@@ -972,8 +988,7 @@ daptm:descType : string
           <p>The <dfn>Script Event Type</dfn> property provides one or more space-separated keywords representing the type of the <a>Script Event</a>,
             i.e. spoken text, or on-screen text,
             and in the latter case, the type of on-screen text (title, credit, location, ...).
-            The possible keywords are indicated in the registry at XXXX.</p>
-          <p class="ednote">Registry to be defined.</p>
+            The possible keywords are indicated in the <a>registry table</a> at <a href="#registry-table-eventType"></a>.</p>
           <p>The <a>Script Event Type</a> is represented in a <a>DAPT Document</a> by the following attribute:
             <div class="exampleInner">
               <pre class="language-abnf">
@@ -2663,8 +2678,263 @@ daptm:eventType : string
     </section> <!-- extensions-->
 
   <section class="appendix">
-      <h2>Acknowledgments</h2>
-      The editors would like to thank XXX for their contributions to this specification.
+    <h2>Registry Section</h2>
+    <section id="registry-definition">
+      <h2>Registry Definition</h2>
+      <p>This section specifies the <a>registry definition</a>, consisting of
+        the custodianship, change process and
+        the core requirements of a <a>registry table</a>.
+      </p>
+      <section id="custodianship">
+        <h3>Custodianship</h3>
+        <p>The <dfn data-cite="w3c-process#custodian">custodian</dfn> of this <a>w3c registry</a> is the
+          <dfn data-abbr="TTWG"><a href="https://www.w3.org/groups/wg/timed-text">Timed Text Working Group</a></dfn>. 
+          If the <a>TTWG</a> is unable to fulfil the role of <a>custodian</a>,
+          for example if it has been <a data-cite="w3c-process#GeneralTermination">closed</a>,
+          the <a>custodian</a> in lieu is the <a>W3C Team</a>.
+        </p>
+      </section>
+      <section id="change-process">
+        <h3>Change Process</h3>
+        <section id="requesting-a-change">
+          <h4>Requesting a change</h4>
+          <p>Changes to this  <a>W3C Registry</a> MUST be requested (the <dfn>change request</dfn>)
+            using any one of the following options:</p>
+          <ul>
+            <li>Open an issue on this document's <span class="pp-vcs">version control system</span>;</li>
+            <li>Send an email to the <a>TTWG</a>'s public email reflector
+              <a href="mailto:public-tt@w3.org">public-tt@w3.org</a></li>
+          </ul>
+          <p>The <a>change request</a> MUST include enough information for the <a>custodian</a>
+            to be able to identify all of:</p>
+          <ul>
+            <li>The <a>registry table</a>;</li>
+            <li>The <a>registry entries</a> being proposed for addition;</li>
+            <li>The <a>provisional</a> <a>registry entries</a> for which changes are being proposed;</li>
+            <li>The <a>registry entries</a> being proposed for a <a>status</a> change;</li>
+            <li>Details of the requested changes for each <a>registry entry</a>;</li>
+            <li>The motivation for making the requested changes;</li>
+            <li>Any other supporting information, for example real world usage statistics;</li>
+          </ul>
+          <p>The proposer of the change MAY open a pull request (or equivalent) on
+            the <span class="pp-vcs">version control system</span>, with that pull request
+            containing the proposed changes. If a pull request is opened then
+            a corresponding issue MUST also be opened and
+            the pull request MUST be linked to that issue.</p>
+          <aside class="note">A pull request representing the proposals made in the <a>change request</a>
+            is required before <a>TTWG</a> review can proceed.</aside>
+        </section>
+        <section id="change-request-assessment">
+          <h4>Change request assessment process</h4>
+          <p>The process for assessing a <a>change request</a> depends on the <a>custodian</a>.</p>
+          <section id="ttwg-change-request-assessment">
+            <h5>Custodian is TTWG</h5>
+            <p>If the <a>custodian</a> is the <a>TTWG</a>:</p>
+            <ul>
+              <li>If the change proposer did not open a pull request
+                on the <span class="pp-vcs">version control system</span>,
+                then assessment is paused until a TTWG member
+                has opened such a pull request,
+                which MUST represent the requested changes
+                and MUST be linked to a related issue.</li>
+              <li>The TTWG follows its Decision Policy to review
+                the proposal in the pull request.</li>
+              <li>At the end of the Decision Review Period
+                if a TTWG Chair declares that there is consensus to approve,
+                the <a>change request</a> is approved.</li>
+              <li>In the absence of consensus to approve the expectation is
+                that a discussion will happen, to include the
+                change requester.
+                The result of this discussion can be any one of:
+                <ol>
+                  <li>the <a>change request</a> is abandoned;</li>
+                  <li>the <a>change request</a> is modified for another review;</li>
+                  <li>if the discussion resolves the objections,
+                    and a TTWG Chair declares consensus to approve,
+                    the <a>change request</a> can be approved.</li>
+                </ol>
+              </li>
+            </ul>
+            <p>An approved <a>change request</a> is enacted by merging its
+              related pull request into the <span class="pp-vcs">version control system</span>
+              and publishing the updated version of this document.</p>
+          </section>
+          <section id="team-change-request-assessment">
+            <h5>Custodian is the W3C Team</h5>
+            <p>If the <a>custodian</a> is the <a>W3C Team</a>,
+              the Team MUST seek <a>wide review</a> of the <a>change request</a> and
+              offer a review period of at least 4 weeks,
+              before assessing from the responses received
+              if there is consensus amongst the respondents.</p>
+            <p>The Team MAY require a pull request on the <span class="pp-vcs">version control system</span>
+              to be opened as the basis of the review.
+            </p>
+            <p>If there is such consensus,
+              the Team MUST make the proposed changes.</p>
+          </section>
+        </section>
+      </section>
+      <h3>Registry Table Constraints</h3>
+      <p>This section defines constraints on <a>registry tables</a>.
+        Each <a>registry table</a> consists of a set of
+        <dfn data-cite="w3c-process#registry-entry" data-lt="registry entry|registry entries">registry entries</dfn>.</p>
+      <section id="registry-entries">
+        <h4>Registry Entries</h4>
+        <p>Each <a>registry entry</a> has a <a>status</a>, a unique <dfn>key</dfn>, and
+          if appropriate, other <dfn>fields</dfn>, for example any notes,
+          a description, or a reference to some other
+          defining entity.
+        </p>
+        <p>The <a>registry table</a> definition MUST define
+          the <a>fields</a> and the <a>key</a> to be used
+          in each <a>registry entry</a>.</p>
+        <aside class="note">It is possible to use any <a>field</a>
+          or combination of <a>fields</a> as the <a>key</a>.
+          For example a <a>field</a> called "4 Character Code"
+          might be used as the <a>key</a>.
+          Another example is two fields called "Short name" and
+          "Revision number" which, in combination,
+          might be used as the <a>key</a>.
+        </aside>
+
+        <section id="registry-entry-status">
+          <h5>Status</h5>
+          <p>The <a>registry entry</a> <dfn>status</dfn> field reflects the maturity of that entry.
+            Permitted values are:</p>
+          <pre>
+            Provisional
+            Final
+            Deprecated
+          </pre>
+          <p>No other values are permitted.</p>
+          <section id="provisional-entry">
+            <h6>Provisional</h6>
+            <p><a>Registry entries</a> with a <a>status</a> of <dfn><code>Provisional</code></dfn> MAY be changed or deleted.
+              Their <a>status</a> may be changed to <a><code>Final</code></a> or <a><code>Deprecated</code></a>.</p>
+            <p><a>Registry entry</a> <a>keys</a> in <a><code>Provisional</code></a> entries
+              that were later deleted MAY be reused.</p>
+            <p>Newly created <a>registry entries</a> SHOULD have <a>status</a> <a><code>Provisional</code></a>.</p>
+          </section>
+          <section id="final-entry">
+            <h6>Final</h6>
+            <p><a>Registry entries</a> with a <a>status</a> of <dfn><code>Final</code></dfn> MUST NOT be deleted or changed.
+              Their <a>status</a> MAY be changed to <a><code>Deprecated</code></a>.</p>
+            <p><a>Registry entry</a> <a>keys</a> in <a><code>Final</code></a> entries MUST NOT be reused.</p>
+            <p>Newly created <a>registry entries</a> MAY have <a>status</a> <a><code>Final</code></a>.</p>
+          </section>
+          <section id="deprecated-entry">
+            <h6>Deprecated</h6>
+            <p><a>Registry entries</a> with a <a>status</a> of <dfn><code>Deprecated</code></dfn> MUST NOT be deleted or changed.
+              Their <a>status</a> MAY be changed to <a><code>Final</code></a>
+              unless that would result in a duplicate <a>key</a> within the set of entries whose
+              <a>status</a> is either <a><code>Provisional</code></a> or <a><code>Final</code></a>.</p>
+            <p><a>Registry entry</a> <a>keys</a> in <a><code>Deprecated</code></a> entries
+              that were previously <code>Provisional</code> and never <a><code>Final</code></a>
+              MAY be reused.</p>
+            <p><a>Registry entry</a> <a>keys</a> in <a><code>Deprecated</code></a> entries
+              that were previously <a><code>Final</code></a> MUST NOT be reused.</p>
+            <p>Newly created <a>registry entries</a> MUST NOT have <a>status</a> <a><code>Deprecated</code></a>.</p>
+          </section>
+        </section>
+      </section>
+    </section>
+    <section id="registry-table">
+      <h2>Registry Tables</h2>
+      <p>This section contains the <a>registry tables</a>, i.e. the set of <a>registry entries</a>.</p>
+      <section id="registry-table-descType">
+        <h3><code>daptm:descType</code></h3>
+        <p>The <a>registry table</a> for <code>daptm:descType</code> defines a set of values that can be
+        used in the <code>daptm:descType</code> attribute.</p>
+        <p>The <a>key</a> is the &quot;<code>daptm:descType</code>&quot; field.
+        The &quot;description&quot; field describes the intended purpose of each value.</p> 
+        <table class="simple">
+          <thead>
+            <th><code>daptm:descType</code></th>
+            <th>Status</th>
+            <th>Description</th>
+            <th>Notes</th>
+          </thead>
+          <tbody>
+            <tr>
+              <td>pronunciationNote</td>
+              <td>Provisional</td>
+              <td>Notes for how to pronounce the content.</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>scene</td>
+              <td>Provisional</td>
+              <td>Contains a scene identifier</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>plotSignificance</td>
+              <td>Provisional</td>
+              <td>Defines a measure of how significant the content is to the plot.</td>
+              <td>Contents are undefined and may be low, medium or high, or a numerical scale.</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section id="registry-table-eventType">
+        <h3><code>daptm:eventType</code></h3>
+        <p>The <a>registry table</a> for <code>daptm:eventType</code> defines a set of values that can be
+          used in the <code>daptm:eventType</code> attribute.</p>
+          <p>The <a>key</a> is the &quot;<code>daptm:eventType</code>&quot; field.
+          The &quot;description&quot; field describes the intended purpose of each value.</p> 
+        <table class="simple">
+          <thead>
+            <th><code>daptm:eventType</code></th>
+            <th>Status</th>
+            <th>Description</th>
+            <th>Notes</th>
+          </thead>
+          <tbody>
+            <tr>
+              <td>dialogue</td>
+              <td>Provisional</td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>spokenText</td>
+              <td>Provisional</td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>onScreenText</td>
+              <td>Provisional</td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>title</td>
+              <td>Provisional</td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>credit</td>
+              <td>Provisional</td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>location</td>
+              <td>Provisional</td>
+              <td></td>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
+        </section>
+    </section>
+  </section>
+
+  <section class="appendix">
+    <h2>Acknowledgments</h2>
+    The editors would like to thank XXX for their contributions to this specification.
   </section>
 
   </body>

--- a/index.html
+++ b/index.html
@@ -2907,7 +2907,9 @@ daptm:eventType : string
       <p>This section defines constraints on the <a>registry tables</a>
         defined in this document.
         Each <a>registry table</a> consists of a set of
-        <dfn data-cite="w3c-process#registry-entry" data-lt="registry entry|registry entries">registry entries</dfn>.</p>
+        <dfn data-cite="w3c-process#registry-entry" data-lt="registry entry|registry entries">registry entries</dfn>.
+        Each <a>registry table</a> has an associated <dfn>registry table definition</dfn> in <a href="#registry-table-definitions"></a>,
+        which lists the <a>fields</a> present in each <a>registry entry</a>.</p>
       <section id="registry-entries">
         <h4>Registry Entries</h4>
         <p>Each <a>registry entry</a> has a <a>status</a>, a unique <dfn>key</dfn>, and
@@ -2915,7 +2917,7 @@ daptm:eventType : string
           a description, or a reference to some other
           defining entity.
         </p>
-        <p>The <a>registry table</a> definition MUST define
+        <p>The <a>registry table definition</a> MUST define
           the <a>fields</a> and the <a>key</a> to be used
           in each <a>registry entry</a>.</p>
         <aside class="note">It is possible to use any <a>field</a>
@@ -2968,7 +2970,7 @@ daptm:eventType : string
         </section>
       </section>
     </section>
-    <section id="registry-table">
+    <section id="registry-table-definitions">
       <h2>Registry Table Definitions</h2>
       <p>This section defines <a>registry tables</a> and locates their <a>registry entries</a>.</p>
       <section id="registry-table-descType">

--- a/index.html
+++ b/index.html
@@ -145,17 +145,16 @@ table.coldividers td + td { border-left:1px solid gray; }
   figure svg {
     max-width: max-content !important;
   }
-  .registry-section::after, .registry-section::before {
+  .registry-section::after, .registry-section::before, .registry-section > .marker {
     color: #444444;
-    background: rgb(175, 238, 238);
+    background: rgb(224, 251, 251);
     display: block;
     text-transform: uppercase;
     margin-left: -0.5em;
     margin-right: -0.5em;
-    padding-left: 0.5em;
-    padding-right: 0.5em;
+    padding: 0.5em;
   }
-  .registry-section::before {
+  .registry-section::before, .registry-section > .marker {
     content: 'Registry section begins';
     margin-top: -0.5em;
     margin-bottom: 0.5em;
@@ -166,13 +165,30 @@ table.coldividers td + td { border-left:1px solid gray; }
     margin-bottom: -0.5em;
   }
   .registry-section {
-    padding: 0.5em;
+    padding: .5em;
+    border: .5em;
+    border-left-style: solid;
+    page-break-inside: avoid;
+    margin: 1em auto;
+    
     border-left-width: 0.5em;
     border-left-style: solid;
     border-right-width: 0.5em;
     border-right-style: solid;
     border-color: #52e0e0;
-    margin: 1em 0;
+
+    overflow: visible;
+    clear: both;
+  }
+  .registry-section a.self-link::before {
+    left: -1.1em;
+    position: relative;
+  }
+  .registry-section:has(:is(h2, h3, h4, h5, h6)) {
+    margin-top: 3rem;
+  }
+  .registry-section > div.header-wrapper :is(h2, h3, h4, h5, h6) {
+    margin-top: 1rem;
   }
   </style>
   </head>
@@ -457,6 +473,14 @@ table.coldividers td + td { border-left:1px solid gray; }
           the <code>&lt;tt&gt;</code> element,
           the following path would be used:
           <code>/tt/head/metadata[0]</code>.
+        </li>
+        <li><a>Registry sections</a> are indicated as follows:
+          <div class="registry-section">
+            <p>Content in registry sections has different requirements
+              for updates than other Recommendation track content,
+              as defined in [[w3c-process]].
+            </p>
+          </div>
         </li>
       </ul>
     </section>

--- a/index.html
+++ b/index.html
@@ -145,7 +145,7 @@ table.coldividers td + td { border-left:1px solid gray; }
   figure svg {
     max-width: max-content !important;
   }
-  .registry-section::after, .registry-section::before, .registry-section > .marker {
+  .registry-table-section::after, .registry-table-section::before, .registry-table-section > .marker {
     color: #444444;
     background: rgb(224, 251, 251);
     display: block;
@@ -154,17 +154,17 @@ table.coldividers td + td { border-left:1px solid gray; }
     margin-right: -0.5em;
     padding: 0.5em;
   }
-  .registry-section::before, .registry-section > .marker {
-    content: 'Registry section begins';
+  .registry-table-section::before, .registry-table-section > .marker {
+    content: 'Registry table section begins';
     margin-top: -0.5em;
     margin-bottom: 0.5em;
   }
-  .registry-section::after {
-    content: 'Registry section ends';
+  .registry-table-section::after {
+    content: 'Registry table section ends';
     margin-top: 0.5em;
     margin-bottom: -0.5em;
   }
-  .registry-section {
+  .registry-table-section {
     padding: .5em;
     border: .5em;
     border-left-style: solid;
@@ -174,21 +174,15 @@ table.coldividers td + td { border-left:1px solid gray; }
     border-left-width: 0.5em;
     border-left-style: solid;
     border-right-width: 0.5em;
-    border-right-style: solid;
+    border-right-style: none;
     border-color: #52e0e0;
 
     overflow: visible;
     clear: both;
   }
-  .registry-section a.self-link::before {
+  .registry-table-section a.self-link::before {
     left: -1.1em;
     position: relative;
-  }
-  .registry-section.has-header {
-    margin-top: 3rem;
-  }
-  .registry-section.has-header > div.header-wrapper :is(h2, h3, h4, h5, h6) {
-    margin-top: 1rem;
   }
   </style>
   </head>
@@ -205,7 +199,9 @@ table.coldividers td + td { border-left:1px solid gray; }
       as defined in the [[w3c-process]] requirements for <a>w3c registries</a>.
       Updates to the document that only change <a>registry tables</a> can be made
       without meeting other requirements for Recommendation track updates,
-      as set out in <dfn data-cite="w3c-process#reg-table-update">Updating Registry Tables</dfn>. 
+      as set out in <dfn data-cite="w3c-process#reg-table-update">Updating Registry Tables</dfn>;
+      requirements for updating those registry tables are normatively specified
+      within <a href="#registry-section"></a>. 
     </section>
 
     <section>
@@ -474,9 +470,9 @@ table.coldividers td + td { border-left:1px solid gray; }
           the following path would be used:
           <code>/tt/head/metadata[0]</code>.
         </li>
-        <li><a>Registry sections</a> are indicated as follows:
-          <div class="registry-section">
-            <p>Content in registry sections has different requirements
+        <li><a>Registry sections</a> that include registry table data are indicated as follows:
+          <div class="registry-table-section">
+            <p>Content in registry table sections has different requirements
               for updates than other Recommendation track content,
               as defined in [[w3c-process]].
             </p>
@@ -1022,11 +1018,11 @@ daptm:onScreen
 daptm:descType : string
             </pre>
           </div>
-          <p>Its permitted values are as indicated in the <a>registry table</a>
-            whose definition is at <a href="#registry-table-descType"></a> and
-            whose values are listed in the following table.</p>
-          <aside class="registry-section">
-            <table class="simple">
+          <p>Its permitted values are listed in the following <a>registry table</a>:</p>
+          <div class="registry-table-section">
+            <table class="data">
+              <caption><a>Registry table</a> for <code>daptm:descType</code>
+                whose Registry Definition is at <a href="#registry-table-descType"></a></caption>
               <thead>
                 <th><code>daptm:descType</code></th>
                 <th>Status</th>
@@ -1054,7 +1050,7 @@ daptm:descType : string
                 </tr>
               </tbody>
             </table>
-          </aside>
+          </div>
           <pre class="example"
             data-include="examples/event-desc-descType.xml"
             data-include-format="text">
@@ -1078,11 +1074,11 @@ daptm:descType : string
 daptm:eventType : string
             </pre>
           </div>
-          <p>Its permitted values are as indicated in the <a>registry table</a>
-          whose definition is at <a href="#registry-table-eventType"></a> and
-          whose values are listed in the following table.</p>
-          <div class="registry-section">
-            <table class="simple">
+          <p>Its permitted values are as listed in the following <a>registry table</a>:</p>
+          <div class="registry-table-section">
+            <table class="data">
+              <caption><a>Registry table</a> for <code>daptm:eventType</code>
+                whose Registry Definition is at <a href="#registry-table-eventType"></a></caption>
               <thead>
                 <th><code>daptm:eventType</code></th>
                 <th>Status</th>
@@ -2810,7 +2806,7 @@ daptm:eventType : string
         </section>
     </section> <!-- extensions-->
 
-  <section class="appendix registry-section has-header">
+  <section class="appendix">
     <h2>Registry Section</h2>
     <section id="registry-definition">
       <h2>Registry Definition</h2>
@@ -2908,7 +2904,8 @@ daptm:eventType : string
         </section>
       </section>
       <h3>Registry Table Constraints</h3>
-      <p>This section defines constraints on <a>registry tables</a>.
+      <p>This section defines constraints on the <a>registry tables</a>
+        defined in this document.
         Each <a>registry table</a> consists of a set of
         <dfn data-cite="w3c-process#registry-entry" data-lt="registry entry|registry entries">registry entries</dfn>.</p>
       <section id="registry-entries">
@@ -2972,15 +2969,15 @@ daptm:eventType : string
       </section>
     </section>
     <section id="registry-table">
-      <h2>Registry Tables</h2>
-      <p>This section contains the <a>registry tables</a>, i.e. the set of <a>registry entries</a>.</p>
+      <h2>Registry Table Definitions</h2>
+      <p>This section defines <a>registry tables</a> and locates their <a>registry entries</a>.</p>
       <section id="registry-table-descType">
         <h3><code>daptm:descType</code> registry table definition</h3>
         <p>The <a>registry table</a> for <code>daptm:descType</code> defines a set of values that can be
         used in the <code>daptm:descType</code> attribute.</p>
         <p>The <a>key</a> is the &quot;<code>daptm:descType</code>&quot; field.
         The &quot;description&quot; field describes the intended purpose of each value.</p> 
-        <p>The table values for this <a>registry table</a> are located in <a href="#script-event-description"></a>.</p>
+        <p>The <a>registry entries</a> for this <a>registry table</a> are located in <a href="#script-event-description"></a>.</p>
       </section>
       <section id="registry-table-eventType">
         <h3><code>daptm:eventType</code> registry table definition</h3>
@@ -2988,7 +2985,7 @@ daptm:eventType : string
           used in the <code>daptm:eventType</code> attribute.</p>
           <p>The <a>key</a> is the &quot;<code>daptm:eventType</code>&quot; field.
           The &quot;description&quot; field describes the intended purpose of each value.</p> 
-          <p>The table values for this <a>registry table</a> are located in <a href="#script-event-type"></a>.</p>
+          <p>The <a>registry entries</a> for this <a>registry table</a> are located in <a href="#script-event-type"></a>.</p>
         </section>
     </section>
   </section>

--- a/index.html
+++ b/index.html
@@ -2838,9 +2838,9 @@ daptm:eventType : string
             to be able to identify all of:</p>
           <ul>
             <li>The <a>registry table</a>;</li>
-            <li>The <a>registry entries</a> being proposed for addition;</li>
-            <li>The <a>provisional</a> <a>registry entries</a> for which changes are being proposed;</li>
-            <li>The <a>registry entries</a> being proposed for a <a>status</a> change;</li>
+            <li>All <a>registry entries</a> being proposed for addition, if any;</li>
+            <li>All <a>provisional</a> <a>registry entries</a> for which changes are being proposed, if any;</li>
+            <li>All <a>registry entries</a> being proposed for a <a>status</a> change, if any;</li>
             <li>Details of the requested changes for each <a>registry entry</a>;</li>
             <li>The motivation for making the requested changes;</li>
             <li>Any other supporting information, for example real world usage statistics;</li>

--- a/index.html
+++ b/index.html
@@ -145,6 +145,35 @@ table.coldividers td + td { border-left:1px solid gray; }
   figure svg {
     max-width: max-content !important;
   }
+  .registry-section::after, .registry-section::before {
+    color: #444444;
+    background: rgb(175, 238, 238);
+    display: block;
+    text-transform: uppercase;
+    margin-left: -0.5em;
+    margin-right: -0.5em;
+    padding-left: 0.5em;
+    padding-right: 0.5em;
+  }
+  .registry-section::before {
+    content: 'Registry section begins';
+    margin-top: -0.5em;
+    margin-bottom: 0.5em;
+  }
+  .registry-section::after {
+    content: 'Registry section ends';
+    margin-top: 0.5em;
+    margin-bottom: -0.5em;
+  }
+  .registry-section {
+    padding: 0.5em;
+    border-left-width: 0.5em;
+    border-left-style: solid;
+    border-right-width: 0.5em;
+    border-right-style: solid;
+    border-color: #52e0e0;
+    margin: 1em 0;
+  }
   </style>
   </head>
   <body>
@@ -963,13 +992,45 @@ daptm:onScreen
           <p>Each <a>Description Type</a> is represented in a <a>DAPT Document</a> by
             a <code>daptm:descType</code> attribute on the <code>&lt;ttm:desc&gt;</code> element.</p>
           <p>The <code>&lt;ttm:desc&gt;</code> element MAY have zero or one <code>daptm:descType</code> attributes.
-            The <code>daptm:descType</code> attribute is defined below.
-            Its possible values are as indicated in the <a>registry table</a> at <a href="#registry-table-descType"></a>.</p>
+            The <code>daptm:descType</code> attribute is defined below.</p>
           <div class="exampleInner">
             <pre class="language-abnf">
 daptm:descType : string
             </pre>
           </div>
+          <p>Its permitted values are as indicated in the <a>registry table</a>
+            whose definition is at <a href="#registry-table-descType"></a> and
+            whose values are listed in the following table.</p>
+          <aside class="registry-section">
+            <table class="simple">
+              <thead>
+                <th><code>daptm:descType</code></th>
+                <th>Status</th>
+                <th>Description</th>
+                <th>Notes</th>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>pronunciationNote</td>
+                  <td>Provisional</td>
+                  <td>Notes for how to pronounce the content.</td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>scene</td>
+                  <td>Provisional</td>
+                  <td>Contains a scene identifier</td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>plotSignificance</td>
+                  <td>Provisional</td>
+                  <td>Defines a measure of how significant the content is to the plot.</td>
+                  <td>Contents are undefined and may be low, medium or high, or a numerical scale.</td>
+                </tr>
+              </tbody>
+            </table>
+          </aside>
           <pre class="example"
             data-include="examples/event-desc-descType.xml"
             data-include-format="text">
@@ -986,25 +1047,74 @@ daptm:descType : string
           <h4>Script Event Type</h4>
           <p>The <dfn>Script Event Type</dfn> property provides one or more space-separated keywords representing the type of the <a>Script Event</a>,
             i.e. spoken text, or on-screen text,
-            and in the latter case, the type of on-screen text (title, credit, location, ...).
-            The possible keywords are indicated in the <a>registry table</a> at <a href="#registry-table-eventType"></a>.</p>
-          <p>The <a>Script Event Type</a> is represented in a <a>DAPT Document</a> by the following attribute:
-            <div class="exampleInner">
-              <pre class="language-abnf">
+            and in the latter case, the type of on-screen text (title, credit, location, ...).</p>
+          <p>The <a>Script Event Type</a> is represented in a <a>DAPT Document</a> by the following attribute:</p>
+          <div class="exampleInner">
+            <pre class="language-abnf">
 daptm:eventType : string
-              </pre>
-            </div>
-            <pre class="example">
-...
-&lt;div xml:id=&quot;event_1&quot;
-     begin=&quot;9663f&quot; end=&quot;9682f&quot; 
-     ttm:agent=&quot;character_4&quot;
-     daptm:eventType=&quot;dialogue&quot;&gt;
-...
-&lt;/div&gt;
-...
             </pre>
-          </p>
+          </div>
+          <p>Its permitted values are as indicated in the <a>registry table</a>
+          whose definition is at <a href="#registry-table-eventType"></a> and
+          whose values are listed in the following table.</p>
+          <div class="registry-section">
+            <table class="simple">
+              <thead>
+                <th><code>daptm:eventType</code></th>
+                <th>Status</th>
+                <th>Description</th>
+                <th>Notes</th>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>dialogue</td>
+                  <td>Provisional</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>spokenText</td>
+                  <td>Provisional</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>onScreenText</td>
+                  <td>Provisional</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>title</td>
+                  <td>Provisional</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>credit</td>
+                  <td>Provisional</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>location</td>
+                  <td>Provisional</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <pre class="example">
+            ...
+            &lt;div xml:id=&quot;event_1&quot;
+                 begin=&quot;9663f&quot; end=&quot;9682f&quot; 
+                 ttm:agent=&quot;character_4&quot;
+                 daptm:eventType=&quot;dialogue&quot;&gt;
+            ...
+            &lt;/div&gt;
+            ...
+                      </pre>
         </section>
       <section>
         <h3>Audio</h3>
@@ -2676,13 +2786,13 @@ daptm:eventType : string
         </section>
     </section> <!-- extensions-->
 
-  <section class="appendix">
+  <section class="appendix registry-section">
     <h2>Registry Section</h2>
     <section id="registry-definition">
       <h2>Registry Definition</h2>
       <p>This section specifies the <a>registry definition</a>, consisting of
         the custodianship, change process and
-        the core requirements of a <a>registry table</a>.
+        the core requirements of the <a>registry tables</a> defined in this document.
       </p>
       <section id="custodianship">
         <h3>Custodianship</h3>
@@ -2841,92 +2951,20 @@ daptm:eventType : string
       <h2>Registry Tables</h2>
       <p>This section contains the <a>registry tables</a>, i.e. the set of <a>registry entries</a>.</p>
       <section id="registry-table-descType">
-        <h3><code>daptm:descType</code></h3>
+        <h3><code>daptm:descType</code> registry table definition</h3>
         <p>The <a>registry table</a> for <code>daptm:descType</code> defines a set of values that can be
         used in the <code>daptm:descType</code> attribute.</p>
         <p>The <a>key</a> is the &quot;<code>daptm:descType</code>&quot; field.
         The &quot;description&quot; field describes the intended purpose of each value.</p> 
-        <table class="simple">
-          <thead>
-            <th><code>daptm:descType</code></th>
-            <th>Status</th>
-            <th>Description</th>
-            <th>Notes</th>
-          </thead>
-          <tbody>
-            <tr>
-              <td>pronunciationNote</td>
-              <td>Provisional</td>
-              <td>Notes for how to pronounce the content.</td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>scene</td>
-              <td>Provisional</td>
-              <td>Contains a scene identifier</td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>plotSignificance</td>
-              <td>Provisional</td>
-              <td>Defines a measure of how significant the content is to the plot.</td>
-              <td>Contents are undefined and may be low, medium or high, or a numerical scale.</td>
-            </tr>
-          </tbody>
-        </table>
+        <p>The table values for this <a>registry table</a> are located in <a href="#script-event-description"></a>.</p>
       </section>
       <section id="registry-table-eventType">
-        <h3><code>daptm:eventType</code></h3>
+        <h3><code>daptm:eventType</code> registry table definition</h3>
         <p>The <a>registry table</a> for <code>daptm:eventType</code> defines a set of values that can be
           used in the <code>daptm:eventType</code> attribute.</p>
           <p>The <a>key</a> is the &quot;<code>daptm:eventType</code>&quot; field.
           The &quot;description&quot; field describes the intended purpose of each value.</p> 
-        <table class="simple">
-          <thead>
-            <th><code>daptm:eventType</code></th>
-            <th>Status</th>
-            <th>Description</th>
-            <th>Notes</th>
-          </thead>
-          <tbody>
-            <tr>
-              <td>dialogue</td>
-              <td>Provisional</td>
-              <td></td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>spokenText</td>
-              <td>Provisional</td>
-              <td></td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>onScreenText</td>
-              <td>Provisional</td>
-              <td></td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>title</td>
-              <td>Provisional</td>
-              <td></td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>credit</td>
-              <td>Provisional</td>
-              <td></td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>location</td>
-              <td>Provisional</td>
-              <td></td>
-              <td></td>
-            </tr>
-          </tbody>
-        </table>
+          <p>The table values for this <a>registry table</a> are located in <a href="#script-event-type"></a>.</p>
         </section>
     </section>
   </section>


### PR DESCRIPTION
Closes #195. Incorporates and modifies the [TTWG boilerplate](https://github.com/w3c/ttwg/blob/fb28a74f733fd7803c7c7ad2eecc27852e4753b8/boilerplate/registry/index.html) registry definition, and specifies starter tables for `daptm:descType` and `daptm:eventType`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/pull/196.html" title="Last updated on Nov 23, 2023, 9:24 AM UTC (ef4ac7e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/196/9de2b7f...ef4ac7e.html" title="Last updated on Nov 23, 2023, 9:24 AM UTC (ef4ac7e)">Diff</a>