### PR TITLE
Always put "element" after element names

### DIFF
--- a/index.html
+++ b/index.html
@@ -389,7 +389,7 @@ table.coldividers td + td { border-left:1px solid gray; }
         </pre>
         <p>After creating audio recordings, if not using text to speech, instructions for playback
           mixing can be inserted. For example, The gain of "received" audio can be changed before mixing in
-          the audio played from inside the <code>span</code>, smoothly
+          the audio played from inside the <code>&lt;span&gt;</code> element, smoothly
           animating the value on the way in and returning it on the way out:
         </p>
         <pre class="example"
@@ -787,8 +787,8 @@ table.coldividers td + td { border-left:1px solid gray; }
             <code>/tt/head/metadata/ttm:agent</code>, with the following constraints:
             <ul>
               <li>The <code>type</code> attribute MUST be set to <code>character</code>.</li>
-              <li>The <code>xml:id</code> attribute MUST be present on the <code>ttm:agent</code> and set to the <a>Character Identifier</a>.</li>
-              <li>The <code>ttm:agent</code> MUST contain a <code>ttm:name</code> element with its <code>type</code> attribute set to <code>alias</code> and its content set to the <a>Character Name</a>.</li>
+              <li>The <code>xml:id</code> attribute MUST be present on the <code>&lt;ttm:agent&gt;</code> element and set to the <a>Character Identifier</a>.</li>
+              <li>The <code>&lt;ttm:agent&gt;</code> element MUST contain a <code>ttm:name</code> element with its <code>type</code> attribute set to <code>alias</code> and its content set to the <a>Character Name</a>.</li>
               <li>If the Character has a <a>Talent Name</a>, it MUST contain a <code>&lt;ttm:actor&gt;</code> child element.
                 That child element MUST have an <code>agent</code> attribute set to
                 the <code>xml:id</code> of the <code>&lt;ttm:agent&gt;</code> element
@@ -922,8 +922,8 @@ table.coldividers td + td { border-left:1px solid gray; }
           <p>A <a>Text</a> object is represented in a <a>DAPT Document</a> by a <code>&lt;p&gt;</code> element with the following constraints:</p>
             <ul>
               <li>The text content of the <code>&lt;p&gt;</code> element is the <a>Text</a> of the <a>Script Event</a>.
-                <aside class="note">The text content of the paragraph can be structured using TTML elements such as
-                  <code>&lt;br&gt;</code> or <code>&lt;span&gt;</code>
+                <aside class="note">The text content of the paragraph can be structured using TTML mark-up such as
+                  <code>&lt;br&gt;</code> or <code>&lt;span&gt;</code> elements
                   which can include or reference TTML style attributes
                   such as <code>tts:ruby</code> used to alter the layout or styling of
                   sections of text within each paragraph.

--- a/index.html
+++ b/index.html
@@ -403,7 +403,7 @@ table.coldividers td + td { border-left:1px solid gray; }
           The first <code>&lt;animate&gt;</code> element drops the gain from 1
           to 0.39 over 0.3s, freezing that value after it ends,
           and the second one raises it back in the
-          final 0.3s of this description. Then the <code>&lt;span&gt;</code> is
+          final 0.3s of this description. Then the <code>&lt;span&gt;</code> element is
           timed to begin only after the first audio dip has finished.</p>
         <p>If the audio recording is long and just a snippet needs to be played,
         that can be done using <code>clipBegin</code> and <code>clipEnd</code>.
@@ -433,7 +433,7 @@ table.coldividers td + td { border-left:1px solid gray; }
           transcribing the audio produces an original language dubbing <a>transcript</a>,
           which can look as follows.
           No specific style or layout is defined, and here the focus is on the transcription of the dialogue.
-          Characters are identified within the <code>&lt;metadata&gt;</code>.
+          Characters are identified within the <code>&lt;metadata&gt;</code> element.
           Note that the language and the <a>text language source</a> are defined using
           <code>xml:lang</code> and <a><code>daptm:langSrc</code></a> respectively,
           which have the same value
@@ -471,8 +471,9 @@ table.coldividers td + td { border-left:1px solid gray; }
         This document uses the following conventions:
       </p>
       <ul>
-        <li>When referring to an [[XML]] element in the prose, angled brackets and a specific style are used as follows: <code>&lt;someElement&gt;</code>. If the name of an element referenced in this specification
-        is not namespace qualified, then the TT namespace applies (see <a href="#namespaces">Namespaces</a>).</li>
+        <li>When referring to an [[XML]] element in the prose, angled brackets and a specific style are used as follows: <code>&lt;someElement&gt;</code>.
+          If the name of an element referenced in this specification
+          is not namespace qualified, then the TT namespace applies (see <a href="#namespaces">Namespaces</a>).</li>
         <li>When referring to an [[XML]] attribute in the prose, the attribute name is given with its prefix,
           or without a prefix if the attribute is in the global namespace.
           Attributes are styled as follows: <code>attributePrefix:attributeName</code>.</li>
@@ -920,7 +921,7 @@ table.coldividers td + td { border-left:1px solid gray; }
           </p>
           <p>A <a>Text</a> object is represented in a <a>DAPT Document</a> by a <code>&lt;p&gt;</code> element with the following constraints:</p>
             <ul>
-              <li>The text content of the <code>&lt;p&gt;</code> is the <a>Text</a> of the <a>Script Event</a>.
+              <li>The text content of the <code>&lt;p&gt;</code> element is the <a>Text</a> of the <a>Script Event</a>.
                 <aside class="note">The text content of the paragraph can be structured using TTML elements such as
                   <code>&lt;br&gt;</code> or <code>&lt;span&gt;</code>
                   which can include or reference TTML style attributes
@@ -1158,7 +1159,7 @@ daptm:onScreen
             Script Event Descriptions can themselves be classified with
             a <a>Description Type</a>.</p>
           <p>A <a>Script Event Description</a> object is represented in a <a>DAPT Document</a> by
-            a <code>&lt;ttm:desc&gt;</code> element at the <code>&lt;div&gt;</code> level.</p>
+            a <code>&lt;ttm:desc&gt;</code> element at the <code>&lt;div&gt;</code> element level.</p>
           <p>Zero or more <code>&lt;ttm:desc&gt;</code> elements MAY be present.</p>
           <p class="note">The <a>Script Event Description</a> does not need to be unique,
             i.e. it does not need to have a different value for each <a>Script Event</a>. 
@@ -2005,7 +2006,7 @@ daptm:eventType : string
           <li><code>&lt;ttm:title&gt;</code></li>
         </ul>
         <p class="note">More guidance about usage of this mechanism is available at <a data-cite="I18N-INLINE-BIDI#nomarkup"></a>.</p>
-        <p>The content elements <code>&lt;p&gt;</code> and <code>&lt;span&gt;</code> permit the direction of text
+        <p>The <code>&lt;p&gt;</code> and <code>&lt;span&gt;</code> content elements permit the direction of text
           to be specified using the <code>tts:direction</code> and <code>tts:unicodeBidi</code> attributes.
           Document authors should use this more robust mechanism rather than using Unicode control characters.</p>
         <div class="note">
@@ -2151,7 +2152,7 @@ daptm:eventType : string
       <li>the application of <em>animated</em> <a>Mixing Instructions</a> is not
         shown explicitly. [[webaudio]] supports the timed variation of
         input parameters to its nodes: it is possible to translate the
-        TTML <code>&lt;animate&gt;</code> semantics directly into
+        TTML <code>&lt;animate&gt;</code> element semantics directly into
         [[webaudio]] API calls to achieve the equivalent effect.</li>
     </ul>
 
@@ -2213,7 +2214,7 @@ daptm:eventType : string
       <thead>
         <tr>
           <th rowspan="2" style="vertical-align: bottom;">DAPT disposition</th>
-          <th colspan="2"><a><code>&lt;ttp:feature&gt;</code></a> or <a><code>&lt;ttp:extension&gt;</code></a> <code>value</code> attribute value in</th>
+          <th colspan="2"><a><code>&lt;ttp:feature&gt;</code></a> or <a><code>&lt;ttp:extension&gt;</code></a> element <code>value</code> attribute value in</th>
         </tr>
         <tr>
           <th><a>content profile</a></th>
@@ -2641,7 +2642,7 @@ daptm:eventType : string
             <td>
               <p>See [[[#ttp-timebase]]].</p>
               <p class="inline-note">NOTE: [[TTML1]] specifies that the default timebase is <code>"media"</code> if
-              <code>ttp:timeBase</code> is not specified on <code>&lt;tt&gt;</code>.</p>
+              <code>ttp:timeBase</code> is not specified on the <code>&lt;tt&gt;</code> element.</p>
             </td>
           </tr>
           <tr>
@@ -2746,7 +2747,7 @@ daptm:eventType : string
             <td><span class="prohibited label">prohibited</span></td>
             <td>
               This is the profile expression of the prohibition of <code>xml:lang</code>
-              on <code>&lt;audio&gt;</code> having a different computed value to the
+              on the <code>&lt;audio&gt;</code> element having a different computed value to the
               parent element and descendant or referenced <code>&lt;source&gt;</code>
               and <code>&lt;data&gt;</code> elements, as specified in
               <a href="#audio-recording"></a>.

--- a/index.html
+++ b/index.html
@@ -435,7 +435,7 @@ table.coldividers td + td { border-left:1px solid gray; }
           No specific style or layout is defined, and here the focus is on the transcription of the dialogue.
           Characters are identified within the <code>&lt;metadata&gt;</code> element.
           Note that the language and the <a>text language source</a> are defined using
-          <code>xml:lang</code> and <a><code>daptm:langSrc</code></a> respectively,
+          <code>xml:lang</code> and <a><code>daptm:langSrc</code></a> attributes respectively,
           which have the same value
           because the transcript is not translated.</p>
         <pre class="example"
@@ -951,15 +951,15 @@ table.coldividers td + td { border-left:1px solid gray; }
                     <a>Script Types</a>, because changing it at the root element could affect
                     the interpretation of descendant elements unexpectedly.
                     In tools that allow fine-grained control,
-                    authors can mitigate this risk by explicitly setting <a><code>daptm:langSrc</code></a>
+                    authors can mitigate this risk by explicitly setting the <a><code>daptm:langSrc</code></a> attribute
                     on all <code>&lt;p&gt;</code> elements.</p>
                   <p>Implementers should take care to ensure that,
-                    when changing <a><code>daptm:langSrc</code></a> on an element,
+                    when changing the <a><code>daptm:langSrc</code></a> attribute on an element,
                     they check down the tree and if appropriate specify the attribute on descendant elements
                     so that their meaning does not change unintentionally.</p>
                 </aside>
                 <aside class="note">
-                  <p>A document that does not specify <a><code>daptm:langSrc</code></a> at all
+                  <p>A document that does not specify the <a><code>daptm:langSrc</code></a> attribute at all
                     implies that all of the text is a transcript of content with no inherent language,
                     for example audio description where no in-image text is transcribed,
                     and which has not been translated.</p>
@@ -975,7 +975,7 @@ table.coldividers td + td { border-left:1px solid gray; }
                   <p>Care should be taken if changing the <a>Default Language</a> of a <a>DAPT Script</a> in case
                     doing so affects descendant elements unexpectedly.
                     In tools that allow fine-grained control,
-                    authors can mitigate this risk by explicitly setting <code>xml:lang</code>
+                    authors can mitigate this risk by explicitly setting the <code>xml:lang</code> attribute
                     on all <code>&lt;p&gt;</code> elements.</p>
                   <p>Implementers should take care to ensure that,
                     when changing the <code>xml:lang</code> attribute on an element,
@@ -1040,7 +1040,7 @@ daptm:langSrc
             <li>The default value is the empty string.</li>
             <li>It <em>applies</em> to <code>&lt;p&gt;</code> and <code>&lt;span&gt;</code> elements.</li>
             <li>It MAY be specified on the following elements: <code>&lt;tt&gt;</code>, <code>&lt;p&gt;</code> and <code>&lt;span&gt;</code>.</li>
-            <li>The inheritance model of <a><code>daptm:langSrc</code></a> is as follows:
+            <li>The inheritance model of the <a><code>daptm:langSrc</code></a> attribute is as follows:
               <ul>
                 <li>If it is present on an element,
                   the computed value is the specified value.</li>
@@ -1049,7 +1049,7 @@ daptm:langSrc
                   the computed value of the same attribute on the element's parent,
                   or if the element has no parent it is the default value.</li>
                </ul>
-              <p class="note">The inheritance model of <a><code>daptm:langSrc</code></a> is intended to match
+              <p class="note">The inheritance model of the <a><code>daptm:langSrc</code></a> attribute is intended to match
                 the inheritance model of the <code>xml:lang</code> attribute [[XML]].</p>
             </li>
             <li>The semantics of the computed value are as follows:
@@ -1059,11 +1059,11 @@ daptm:langSrc
                   and sourced from content without an inherent language.</li>
                 <li>Otherwise (the computed value is not empty)
                   <ul>
-                    <li>if the computed value is the same as the computed value of <code>xml:lang</code>,
+                    <li>if the computed value is the same as the computed value of the <code>xml:lang</code> attribute,
                     then it indicates that the <a>Text</a> is <a>Original</a>
                     and sourced from content with an inherent language.</li>
                     <li>Otherwise (the computed value
-                    differs from the computed value of <code>xml:lang</code>),
+                    differs from the computed value of the <code>xml:lang</code> attribute),
                     it indicates that the <a>Text</a> is a <a>translation</a>,
                     and the computed value is the language from which the <a>Text</a> was translated.</li>
                   </ul>
@@ -1075,7 +1075,7 @@ daptm:langSrc
           <aside class="example">
             <table class="simple">
               <caption>Table enumerating example values of the <code>xml:lang</code> and
-                <code>daptm:langSrc</code> attributes for different <a>Original</a> transcript sources and
+                <a><code>daptm:langSrc</code></a> attributes for different <a>Original</a> transcript sources and
                 their inherent languages.
               </caption>
               <thead>
@@ -1114,8 +1114,8 @@ daptm:langSrc
               </tbody>
             </table>
             <p>If any of these transcripts were translated,
-              the resulting <a>Text</a> would have its <a><code>daptm:langSrc</code></a>
-              set to the computed <code>xml:lang</code>
+              the resulting <a>Text</a> would have its <a><code>daptm:langSrc</code></a> attribute
+              set to the computed value of the <code>xml:lang</code> attribute
               of the source.</p>
             <p>For example, if the Arabic dialogue were translated into Japanese,
               it would result in <code>xml:lang="ja"</code> and <code>daptm:langSrc="ar"</code>.</p>
@@ -1195,7 +1195,7 @@ daptm:descType : string
           <p>Its permitted values are listed in the following <a>registry table</a>:</p>
           <div class="registry-table-section">
             <table class="data">
-              <caption><a>Registry table</a> for <code>daptm:descType</code>
+              <caption><a>Registry table</a> for the <code>daptm:descType</code> attribute
                 whose Registry Definition is at <a href="#registry-table-descType"></a></caption>
               <thead>
                 <th><code>daptm:descType</code></th>
@@ -1230,7 +1230,7 @@ daptm:descType : string
             data-include-format="text">
           </pre>
           <p>Amongst a sibling group of <code>&lt;ttm:desc&gt;</code> elements
-            there are no constraints on the uniqueness of <code>daptm:descType</code>,
+            there are no constraints on the uniqueness of the <code>daptm:descType</code> attribute,
             however it may be useful as a distinguisher as shown in the following example.</p>
           <pre class="example"
             data-include="examples/event-desc-multiple-descType.xml"
@@ -1251,7 +1251,7 @@ daptm:eventType : string
           <p>Its permitted values are as listed in the following <a>registry table</a>:</p>
           <div class="registry-table-section">
             <table class="data">
-              <caption><a>Registry table</a> for <code>daptm:eventType</code>
+              <caption><a>Registry table</a> for the <code>daptm:eventType</code> attribute
                 whose Registry Definition is at <a href="#registry-table-eventType"></a></caption>
               <thead>
                 <th><code>daptm:eventType</code></th>
@@ -1842,7 +1842,7 @@ daptm:eventType : string
             the designator of the <a>DAPT 1.0 Processor Profile</a>.
             Other values MAY be present to declare additional processing constraints, 
             and MAY include profile designators in proprietary namespaces.</p>
-          <p class="note"><a><code>ttp:processorProfiles</code></a> can be used
+          <p class="note">The <a><code>ttp:processorProfiles</code></a> attribute can be used
             to signal that features and extensions in additional profiles
             need to be supported to process the <a>Document Instance</a> successfully.
             For example, a local workflow might introduce particular metadata requirements,
@@ -1851,7 +1851,7 @@ daptm:eventType : string
           <p class="note">If the content author does not need to signal that
             additional processor requirements than those defined by DAPT
             are needed to process the <a>DAPT document</a> then the
-            <a><code>ttp:processorProfiles</code></a> is not expected to be present.</p>
+            <a><code>ttp:processorProfiles</code></a> attribute is not expected to be present.</p>
         </section>
 
         <section>
@@ -2750,7 +2750,7 @@ daptm:eventType : string
             <td><a href="#xmllang-audio-nonmatching"><code>#xmlLang-audio-nonMatching</code></a></td>
             <td><span class="prohibited label">prohibited</span></td>
             <td>
-              This is the profile expression of the prohibition of <code>xml:lang</code>
+              This is the profile expression of the prohibition of the <code>xml:lang</code> attribute
               on the <code>&lt;audio&gt;</code> element having a different computed value to the
               parent element and descendant or referenced <code>&lt;source&gt;</code>
               and <code>&lt;data&gt;</code> elements, as specified in

--- a/index.html
+++ b/index.html
@@ -356,7 +356,7 @@ table.coldividers td + td { border-left:1px solid gray; }
           but in this empty example, it is not relevant, since only the structure of the document is shown.</li>
           <li>The <a><code>daptm:langSrc</code></a> attribute indicates the default text language source,
             for example the original language of the content,
-            while the <code>xml:lang</code> indicates the default language 
+            while the <code>xml:lang</code> attribute indicates the default language 
             in this script, which in this case is the same.
             Both of these attributes are inherited and can be overridden within the content of the document.</li>
         </ul>
@@ -397,7 +397,7 @@ table.coldividers td + td { border-left:1px solid gray; }
           data-include-format="text">
         </pre>
         <p>In the above example, the <code>&lt;div&gt;</code> element's
-          <code>begin</code> time becomes the "syncbase" for its child, 
+          <code>begin</code> attribute defines the time that is the "syncbase" for its child, 
           so the times on the <code>&lt;animate&gt;</code> and <code>&lt;span&gt;</code>
           elements are relative to 25s here.
           The first <code>&lt;animate&gt;</code> element drops the gain from 1
@@ -471,12 +471,16 @@ table.coldividers td + td { border-left:1px solid gray; }
         This document uses the following conventions:
       </p>
       <ul>
-        <li>When referring to an [[XML]] element in the prose, angled brackets and a specific style are used as follows: <code>&lt;someElement&gt;</code>.
+        <li>When referring to an [[XML]] element in the prose,
+          angled brackets and a specific style are used as follows: <code>&lt;someElement&gt;</code>.
+          The entity is also described as an element in the prose.
           If the name of an element referenced in this specification
           is not namespace qualified, then the TT namespace applies (see <a href="#namespaces">Namespaces</a>).</li>
-        <li>When referring to an [[XML]] attribute in the prose, the attribute name is given with its prefix,
+        <li>When referring to an [[XML]] attribute in the prose,
+          the attribute name is given with its prefix,
           or without a prefix if the attribute is in the global namespace.
-          Attributes are styled as follows: <code>attributePrefix:attributeName</code>.</li>
+          Attributes are styled as follows: <code>attributePrefix:attributeName</code>.
+          The entity is also described as an attribute in the prose.</li>
         <li>When defining new [[XML]] attributes, this specification uses the conventions used for
         "value syntax expressions" in [[TTML2]]. For example, the following would define a new attribute
         called <code>daptm:foo</code> as a string with two possible values:
@@ -605,11 +609,11 @@ table.coldividers td + td { border-left:1px solid gray; }
             </pre>
           </div>
 
-          <p>The definitions of the types of documents and the corresponding <code>daptm:scriptType</code> values are:
+          <p>The definitions of the types of documents and the corresponding <code>daptm:scriptType</code> attribute values are:
             <ul>
               <li>
                 <dfn>Original Language Transcript</dfn>:
-                <p>When the <code>daptm:scriptType</code> value is <code>originalTranscript</code>,
+                <p>When the <code>daptm:scriptType</code> attribute value is <code>originalTranscript</code>,
                 the document is a literal transcription of the dialogue and/or on-screen text in their inherent spoken/written language(s),
                 or of non-dialogue sounds and non-linguistic visual content.</p>
                 <p><a>Script Events</a> in this type of <a>transcript</a> SHOULD contain
@@ -622,7 +626,7 @@ table.coldividers td + td { border-left:1px solid gray; }
               </li>
               <li>
                 <dfn>Translated Transcript</dfn>:
-                <p>When the <code>daptm:scriptType</code> value is <code>translatedTranscript</code>,
+                <p>When the <code>daptm:scriptType</code> attribute value is <code>translatedTranscript</code>,
                 the document represents a translation of the <a>Original Language Transcript</a> in a common language.</p>
                 <p>It can be adapted to produce a <a>Pre-Recording Script</a>,
                   and/or used as the basis for a further translation into the <a>Target Recording Language</a>.</p> 
@@ -644,7 +648,7 @@ table.coldividers td + td { border-left:1px solid gray; }
                 </li>
               <li>
                 <dfn>Pre-recording Script</dfn>:
-                <p>When the <code>daptm:scriptType</code> value is <code>preRecording</code>,
+                <p>When the <code>daptm:scriptType</code> attribute value is <code>preRecording</code>,
                 the document represents the result of the adaptation of an <a>Original Language Transcript</a> or
                 a <a>Translated Transcript</a> for recording, e.g. for better lip-sync in a dubbing workflow,
                 or to ensure that the words can fit within the time available in an audio description workflow.</p>
@@ -673,7 +677,7 @@ table.coldividers td + td { border-left:1px solid gray; }
               </li>
               <li>
                 <dfn>As-recorded Script</dfn>:
-                <p>When the <code>daptm:scriptType</code> value is <code>asRecorded</code>, 
+                <p>When the <code>daptm:scriptType</code> attribute value is <code>asRecorded</code>, 
                 the document represents the actual audio recording.</p>
                 <p><a>Script Events</a> in this type of <a>script</a> SHOULD contain <a>Text</a> objects
                   in the <a>Target Recording Language</a>
@@ -770,7 +774,7 @@ table.coldividers td + td { border-left:1px solid gray; }
                   <li>its <code>type</code> attribute MUST be set to <code>person</code></li>
                   <li>its <code>xml:id</code> attribute MUST be set.</li>
                   <li>it MUST have a <code>&lt;ttm:name&gt;</code> child element whose
-                    <code>type</code> MUST be set to <code>full</code> and its content set to the <a>Talent Name</a></li>
+                    <code>type</code> attribute MUST be set to <code>full</code> and its content set to the <a>Talent Name</a></li>
                 </ul>
               </li>
               <li>If more than one <a>Character</a> is associated with the same
@@ -788,12 +792,12 @@ table.coldividers td + td { border-left:1px solid gray; }
             <ul>
               <li>The <code>type</code> attribute MUST be set to <code>character</code>.</li>
               <li>The <code>xml:id</code> attribute MUST be present on the <code>&lt;ttm:agent&gt;</code> element and set to the <a>Character Identifier</a>.</li>
-              <li>The <code>&lt;ttm:agent&gt;</code> element MUST contain a <code>ttm:name</code> element with its <code>type</code> attribute set to <code>alias</code> and its content set to the <a>Character Name</a>.</li>
+              <li>The <code>&lt;ttm:agent&gt;</code> element MUST contain a <code>&lt;ttm:name&gt;</code> element with its <code>type</code> attribute set to <code>alias</code> and its content set to the <a>Character Name</a>.</li>
               <li>If the Character has a <a>Talent Name</a>, it MUST contain a <code>&lt;ttm:actor&gt;</code> child element.
                 That child element MUST have an <code>agent</code> attribute set to
-                the <code>xml:id</code> of the <code>&lt;ttm:agent&gt;</code> element
+                the value of the <code>xml:id</code> attribute of the <code>&lt;ttm:agent&gt;</code> element
                 corresponding to the <a>Talent Name</a>,
-                that is, whose <code>type</code> is set to <code>person</code>.</li>
+                that is, whose <code>type</code> attribute is set to <code>person</code>.</li>
             </ul>
 
           <pre class="example">
@@ -874,7 +878,7 @@ table.coldividers td + td { border-left:1px solid gray; }
                 <p class="note">See <a href="#timing-properties"></a> for additional notes on timing properties.</p>
               </li>
               <li>The <code>ttm:agent</code> attribute MAY be present and if present,
-                MUST contain a reference to each <code>ttm:agent</code> that represents an associated <a>Character</a>.
+                MUST contain a reference to each <code>ttm:agent</code> attribute that represents an associated <a>Character</a>.
               <aside class="note">Multiple references are specified using a space-separated list.</aside>
           <pre class="example">
 ...
@@ -974,7 +978,7 @@ table.coldividers td + td { border-left:1px solid gray; }
                     authors can mitigate this risk by explicitly setting <code>xml:lang</code>
                     on all <code>&lt;p&gt;</code> elements.</p>
                   <p>Implementers should take care to ensure that,
-                    when changing <code>xml:lang</code> on an element,
+                    when changing the <code>xml:lang</code> attribute on an element,
                     they check down the tree and if appropriate specify the attribute on descendant elements
                     so that their meaning does not change unintentionally.</p>
                 </aside>
@@ -1070,8 +1074,8 @@ daptm:langSrc
           <p class="note">An example of the usage of <a>Text Language Source</a> in a document is present in the <a>Text</a> section.</p>
           <aside class="example">
             <table class="simple">
-              <caption>Table enumerating example values of <code>xml:lang</code> and
-                <code>daptm:langSrc</code> for different <a>Original</a> transcript sources and
+              <caption>Table enumerating example values of the <code>xml:lang</code> and
+                <code>daptm:langSrc</code> attributes for different <a>Original</a> transcript sources and
                 their inherent languages.
               </caption>
               <thead>
@@ -1130,7 +1134,7 @@ daptm:langSrc
             <li>OFF_ON - the <a>Script Event</a>'s subject starts off screen, but goes on screen at some point</li>
           </ul>
           <p>If omitted, the default value is "ON".</p>
-          <aside class="note">When <a>daptm:workflowType</a> is set to <code>audioDescription</code> the subject of each
+          <aside class="note">When the <a>daptm:workflowType</a> attribute is set to <code>audioDescription</code> the subject of each
             <a>Script Event</a>, i.e. what is being described,
             is expected to be in the video image, therefore the default of "ON" allows
             the property to be omitted in those cases without distortion of meaning.</aside>
@@ -1495,8 +1499,8 @@ daptm:eventType : string
             </li>
             <li><a>Mixing Instructions</a> MAY be applied as specified in their
               <a href="#mixing-instruction-ttml">TTML representation</a>;</li>
-            <li>The computed value of <code>xml:lang</code> MUST be identical
-              to the computed value of <code>xml:lang</code> of the parent element
+            <li>The computed value of the <code>xml:lang</code> attribute MUST be identical
+              to the computed value of the <code>xml:lang</code> attribute of the parent element
               and any child <code>&lt;source&gt;</code> elements
               and any referenced embedded <code>&lt;data&gt;</code> elements.</li>
           </ul>
@@ -1528,7 +1532,7 @@ daptm:eventType : string
           <p>The TTML representation of a <a>Synthesized Audio</a>
             is illustrated by <a href="#example-6"></a>.</p>
           <p class="note">A <code>tta:pitch</code> attribute on an element
-            whose computed value of <code>tta:rate</code> is <code>none</code>
+            whose computed value of the <code>tta:rate</code> attribute is <code>none</code>
             has no effect.
             Such an element is not considered to have an associated <a>Synthesized Audio</a>.</p>
           <p class="note">The semantics of the <a>Synthesized Audio</a> vocabulary of DAPT are derived from equivalent features in [[SSML]] as indicated in [[TTML2]]. This version
@@ -1887,7 +1891,7 @@ daptm:eventType : string
         <p>Within a DAPT Script, the following constraints apply in relation to time attributes and time expressions:</p>
         <section>
           <h4><code>ttp:timeBase</code></h4>
-          <p>The only permitted <code>ttp:timeBase</code> value is <code>media</code>,
+          <p>The only permitted <code>ttp:timeBase</code> attribute value is <code>media</code>,
             since <a href="#profiles"></a> prohibits all timeBase features
             other than <a href="https://www.w3.org/TR/ttml2/#feature-timeBase-media"><code>#timeBase-media</code></a>.</p>
           <p>This means that the beginning of the document timeline,
@@ -2642,7 +2646,7 @@ daptm:eventType : string
             <td>
               <p>See [[[#ttp-timebase]]].</p>
               <p class="inline-note">NOTE: [[TTML1]] specifies that the default timebase is <code>"media"</code> if
-              <code>ttp:timeBase</code> is not specified on the <code>&lt;tt&gt;</code> element.</p>
+              the <code>ttp:timeBase</code> attribute is not specified on the <code>&lt;tt&gt;</code> element.</p>
             </td>
           </tr>
           <tr>


### PR DESCRIPTION
Closes #199.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/pull/209.html" title="Last updated on Feb 8, 2024, 3:02 PM UTC (64ffdd0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/209/9f1e09d...64ffdd0.html" title="Last updated on Feb 8, 2024, 3:02 PM UTC (64ffdd0)">Diff</a>