### PR TITLE
Switch the bullet order in Character

### DIFF
--- a/index.html
+++ b/index.html
@@ -773,7 +773,7 @@ table.coldividers td + td { border-left:1px solid gray; }
               <li>The <code>&lt;ttm:agent&gt;</code> element MUST contain a <code>&lt;ttm:name&gt;</code> element with its <code>type</code> attribute set to <code>alias</code> and its content set to the <a>Character Name</a>.</li>
               <li><p>If the Character has a <a>Talent Name</a>, it MUST contain a <code>&lt;ttm:actor&gt;</code> child element.
                 That child element MUST have an <code>agent</code> attribute set to
-                the value of the <code>xml:id</code> attribute of the <code>&lt;ttm:agent&gt;</code> element
+                the value of the <code>xml:id</code> attribute of a separate <code>&lt;ttm:agent&gt;</code> element
                 corresponding to the <a>Talent Name</a>,
                 that is, whose <code>type</code> attribute is set to <code>person</code>.</p>
                 <p class="note">The requirement for an additional <code>&lt;ttm:agent&gt;</code> element

--- a/index.html
+++ b/index.html
@@ -765,28 +765,6 @@ table.coldividers td + td { border-left:1px solid gray; }
         </p>
         <p>A <a>Character</a> is represented in a <a>DAPT Document</a> by the following structure and constraints:</p>
         <ul>
-          <li>If the <a>Character</a> has a <a>Talent Name</a> property:
-            <ul>
-              <li>A <code>&lt;ttm:agent&gt;</code> element corresponding to the <a>Talent Name</a> 
-                MUST be present at the path
-                <code>/tt/head/metadata/ttm:agent</code>, with the following constraints:
-                <ul>
-                  <li>its <code>type</code> attribute MUST be set to <code>person</code></li>
-                  <li>its <code>xml:id</code> attribute MUST be set.</li>
-                  <li>it MUST have a <code>&lt;ttm:name&gt;</code> child element whose
-                    <code>type</code> attribute MUST be set to <code>full</code> and its content set to the <a>Talent Name</a></li>
-                </ul>
-              </li>
-              <li>If more than one <a>Character</a> is associated with the same
-                <a>Talent Name</a> there SHOULD be a single
-                <code>&lt;ttm:agent&gt;</code> element corresponding to that <a>Talent Name</a>,
-                referenced separately by each of the <a>Characters</a>.</li>
-              <li>Each <code>&lt;ttm:agent&gt;</code> element corresponding to a <a>Talent Name</a>
-                SHOULD appear before any of the <a>Character</a> <code>&lt;ttm:agent&gt;</code> elements
-                whose <code>&lt;ttm:actor&gt;</code> child element references it.</li>
-            </ul>
-          </li>
-
           <li>The <a>Character</a> is represented in a <a>DAPT Document</a> by a <code>&lt;ttm:agent&gt;</code> element present at the path
             <code>/tt/head/metadata/ttm:agent</code>, with the following constraints:
             <ul>
@@ -824,6 +802,29 @@ table.coldividers td + td { border-left:1px solid gray; }
 ...
           </pre>
           </li>
+
+          <li>If the <a>Character</a> has a <a>Talent Name</a> property:
+            <ul>
+              <li>A <code>&lt;ttm:agent&gt;</code> element corresponding to the <a>Talent Name</a> 
+                MUST be present at the path
+                <code>/tt/head/metadata/ttm:agent</code>, with the following constraints:
+                <ul>
+                  <li>its <code>type</code> attribute MUST be set to <code>person</code></li>
+                  <li>its <code>xml:id</code> attribute MUST be set.</li>
+                  <li>it MUST have a <code>&lt;ttm:name&gt;</code> child element whose
+                    <code>type</code> MUST be set to <code>full</code> and its content set to the <a>Talent Name</a></li>
+                </ul>
+              </li>
+              <li>If more than one <a>Character</a> is associated with the same
+                <a>Talent Name</a> there SHOULD be a single
+                <code>&lt;ttm:agent&gt;</code> element corresponding to that <a>Talent Name</a>,
+                referenced separately by each of the <a>Characters</a>.</li>
+              <li>Each <code>&lt;ttm:agent&gt;</code> element corresponding to a <a>Talent Name</a>
+                SHOULD appear before any of the <a>Character</a> <code>&lt;ttm:agent&gt;</code> elements
+                whose <code>&lt;ttm:actor&gt;</code> child element references it.</li>
+            </ul>
+          </li>
+
           <li>All <code>&lt;ttm:agent&gt;</code> elements SHOULD be contained in the first <code>&lt;metadata&gt;</code> element in the <code>&lt;head&gt;</code> element.
             <div class="note">There can be multiple <code>&lt;metadata&gt;</code> elements in the <code>&lt;head&gt;</code> element,
             for example to include <a href="#proprietary-metadata">proprietary metadata</a>

--- a/index.html
+++ b/index.html
@@ -771,11 +771,13 @@ table.coldividers td + td { border-left:1px solid gray; }
               <li>The <code>type</code> attribute MUST be set to <code>character</code>.</li>
               <li>The <code>xml:id</code> attribute MUST be present on the <code>&lt;ttm:agent&gt;</code> element and set to the <a>Character Identifier</a>.</li>
               <li>The <code>&lt;ttm:agent&gt;</code> element MUST contain a <code>&lt;ttm:name&gt;</code> element with its <code>type</code> attribute set to <code>alias</code> and its content set to the <a>Character Name</a>.</li>
-              <li>If the Character has a <a>Talent Name</a>, it MUST contain a <code>&lt;ttm:actor&gt;</code> child element.
+              <li><p>If the Character has a <a>Talent Name</a>, it MUST contain a <code>&lt;ttm:actor&gt;</code> child element.
                 That child element MUST have an <code>agent</code> attribute set to
                 the value of the <code>xml:id</code> attribute of the <code>&lt;ttm:agent&gt;</code> element
                 corresponding to the <a>Talent Name</a>,
-                that is, whose <code>type</code> attribute is set to <code>person</code>.</li>
+                that is, whose <code>type</code> attribute is set to <code>person</code>.</p>
+                <p class="note">The requirement for an additional <code>&lt;ttm:agent&gt;</code> element
+                  corresponding to the <a>Talent Name</a> is defined in the following bullet list.</p></li>
             </ul>
 
           <pre class="example">


### PR DESCRIPTION
Closes #172. Switches the order of the first two bullets in the representation of Character in §4.2.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/pull/211.html" title="Last updated on Feb 13, 2024, 6:11 PM UTC (8b6f504)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/211/8c90163...8b6f504.html" title="Last updated on Feb 13, 2024, 6:11 PM UTC (8b6f504)">Diff</a>