### PR TITLE
Adds permitted feature `#scriptEventGrouping`

### DIFF
--- a/index.html
+++ b/index.html
@@ -3197,6 +3197,14 @@ daptm:eventType : string
             </td>
           </tr>
           <tr>
+            <td><a href="#scripteventgrouping"><code>#scriptEventGrouping</code></a></td>
+            <td><span class="permitted label">permitted</span></td>
+            <td>
+              This is the profile expression of the permission to nest
+              <code>&lt;div&gt;</code> elements described in <a href="#script-event"></a>.
+            </td>
+          </tr>
+          <tr>
             <td><a href="#scripteventmapping"><code>#scriptEventMapping</code></a></td>
             <td><span class="optional label">optional</span></td>
             <td>
@@ -3376,6 +3384,20 @@ daptm:eventType : string
           conformance to that profile either does not have a
           <a><code>daptm:represents</code></a> attribute on the <code>&lt;tt&gt;</code> element
           or has one whose value is not conformant with the requirements defined herein.</p>
+      </section>
+
+      <section>
+        <h3>#scriptEventGrouping</h3>
+        <p>A <a>transformation processor</a> supports the <code>#scriptEventGrouping</code> extension if
+          it recognises and is capable of transforming <code>&lt;div&gt;</code> elements
+          that contain <code>&lt;div&gt;</code> elements.</p>
+  
+        <p class="note">Support for the <code>#scriptEventGrouping</code> extension does not imply
+          support for the <code>#scriptEventMapping</code> extension.</p>
+
+        <p>A <a>presentation processor</a> supports the <code>#scriptEventGrouping</code> extension if
+          it implements presentation semantic support for <code>&lt;div&gt;</code> elements
+          that contain <code>&lt;div&gt;</code> elements.</p>
       </section>
 
       <section>

--- a/index.html
+++ b/index.html
@@ -263,6 +263,7 @@
         <div class="issue" data-number="222"></div>
         <div class="issue" data-number="223"></div>
         <div class="issue" data-number="224"></div>
+        <div class="issue" data-number="239"></div>
   
         <p><a>At risk</a> features may be be removed before advancement to Proposed Recommendation.</p>
     </section>

--- a/profiles/dapt-content-profile.xml
+++ b/profiles/dapt-content-profile.xml
@@ -91,6 +91,7 @@
     <!-- optional (voluntary) extension support -->
     <extension value="optional">#agent</extension>
     <extension value="optional">#onScreen</extension>
+    <extension value="optional">#scriptEventGrouping</extension>
     <extension value="optional">#scriptEventMapping</extension>
     <extension value="optional">#textLanguageSource</extension>
     <!-- prohibited extension support -->

--- a/profiles/dapt-processor-profile.xml
+++ b/profiles/dapt-processor-profile.xml
@@ -86,6 +86,7 @@
     <extension value="required">#contentProfiles-root</extension>
     <extension value="required">#onScreen</extension>
     <extension value="required">#represents-root</extension>
+    <extension value="required">#scriptEventGrouping</extension>
     <extension value="required">#scriptType-root</extension>
     <extension value="required">#serialization</extension>
     <extension value="required">#textLanguageSource</extension>


### PR DESCRIPTION
Closes #237.

Includes issue link to #239 as an at-risk feature.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/pull/238.html" title="Last updated on Aug 30, 2024, 3:54 PM UTC (5644290)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/238/9b62fff...5644290.html" title="Last updated on Aug 30, 2024, 3:54 PM UTC (5644290)">Diff</a>