### PR TITLE
Add media zero timecode and start of programme timecode metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -1123,7 +1123,9 @@
               </ul>
               <p>When the related media's timecode is later dicovered,
                 the times of the <a>Script Events</a> can be adjusted so that
-                the zero points are coincident.
+                media time zero is coincident with the beginning of the
+                related media, and the <a>Media Zero Timecode</a> can be
+                removed or set to the now-known value.
               </p>
             </div>
           </section>

--- a/index.html
+++ b/index.html
@@ -2120,7 +2120,7 @@ daptm:descType : string
       </section>
 
       <section>
-        <h3>Related Media Object (TTML)</h3>
+        <h3>Related Media Object</h3>
         <p>Within DAPT, the common language terms audio and video are used in the context of a programme.
           The audio and video are each a part of what is defined in [[TTML2]] as the
           <dfn data-cite="TTML2#terms-related-media-object">Related Media Object</dfn> that
@@ -2774,8 +2774,6 @@ daptm:descType : string
       during presentation.
     </p>
 
-    <p>A <a>DAPT Script</a> MAY contain zero or one <a>DAPT Origin Timecode</a> objects.</p>
-    <p>A <a>DAPT Script</a> MAY contain zero or one <a>Start of Programme Timecode</a> objects.</p>
     <p>If either a <a>DAPT Origin Timecode</a> object
       or a <a>Start of Programme Timecode</a> object is present,
       the <a>DAPT Document</a> MUST have

--- a/index.html
+++ b/index.html
@@ -2764,7 +2764,7 @@ daptm:descType : string
       a common issue occurs if the timecode of
       the beginning of the media is not known at the time of conversion.
     </p>
-    <p>The optional <a>Media Zero Timecode</a> and
+    <p>The optional <a>DAPT Origin Timecode</a> and
       <a>Start of Programme Timecode</a> properties can be used to
       identify when there is a possible synchronisation error,
       and to resynchronise the document when all
@@ -2774,9 +2774,9 @@ daptm:descType : string
       during presentation.
     </p>
 
-    <p>A <a>DAPT Script</a> MAY contain zero or one <a>Media Zero Timecode</a> objects.</p>
+    <p>A <a>DAPT Script</a> MAY contain zero or one <a>DAPT Origin Timecode</a> objects.</p>
     <p>A <a>DAPT Script</a> MAY contain zero or one <a>Start of Programme Timecode</a> objects.</p>
-    <p>If either a <a>Media Zero Timecode</a> object
+    <p>If either a <a>DAPT Origin Timecode</a> object
       or a <a>Start of Programme Timecode</a> object is present,
       the <a>DAPT Document</a> MUST have
       one <code>&lt;head&gt;</code> element child of the <code>&lt;tt&gt;</code> element,
@@ -2784,29 +2784,29 @@ daptm:descType : string
       at least one <code>&lt;metadata&gt;</code> element child.</p>
 
     <section>
-      <h5>Media Zero Timecode</h5>
-      <p>The optional <dfn>Media Zero Timecode</dfn> allows a timecode value to be declared
+      <h5>DAPT Origin Timecode</h5>
+      <p>The optional <dfn>DAPT Origin Timecode</dfn> allows a timecode value to be declared
         that corresponds to the zero point on the media timeline,
         that is, the time of a hypothetical <a>Script Event</a> whose <a>Begin</a> is
         zero seconds on the media timeline.</p>
-      <p>A <a>DAPT Script</a> MAY contain zero or one <a>Media Zero Timecode</a> objects.</p>
-      <p>The <a>Media Zero Timecode</a> object is represented in a <a>DAPT Document</a> by
-        a <code>&lt;</code><dfn><code>daptm:mediaZeroTimecode</code></dfn><code>&gt;</code> element present at the path
-        <code>/tt/head/metadata/daptm:mediaZeroTimecode</code>,
+      <p>A <a>DAPT Script</a> MAY contain zero or one <a>DAPT Origin Timecode</a> objects.</p>
+      <p>The <a>DAPT Origin Timecode</a> object is represented in a <a>DAPT Document</a> by
+        a <code>&lt;</code><dfn><code>daptm:daptOriginTimecode</code></dfn><code>&gt;</code> element present at the path
+        <code>/tt/head/metadata/daptm:daptOriginTimecode</code>,
         with the following constraints:</p>
       <ul>
         <li>The character content of the element must conform to a <code>clock-time</code>
           with a <code>frames</code> component, as defined in <dfn data-cite="ttml2#timing-value-time-expression">&lt;time-expression&gt;</dfn>.</li>
       </ul>
       <p class="note">See also <a href="#ttp-framerate"></a>.
-        No mechanism is defined here for declaring a different frame rate for the <a>Media Zero Timecode</a>
+        No mechanism is defined here for declaring a different frame rate for the <a>DAPT Origin Timecode</a>
         than is used for other frame-based time expressions.
       </p>
       <pre class="example">
 ...
 &lt;head&gt;
 &lt;metadata&gt;
-&lt;daptm:mediaZeroTimecode&gt;10:01:20:12&lt;/daptm:mediaZeroTimecode&gt;
+&lt;daptm:daptOriginTimecode&gt;10:01:20:12&lt;/daptm:daptOriginTimecode&gt;
 &lt;/metadata&gt;
 &lt;/head&gt;
 &lt;body&gt;
@@ -2820,11 +2820,11 @@ daptm:descType : string
         <p>When converting legacy formats that store the equivalent of each Script Event,
           for example a <a>description</a>, with SMPTE timecodes,
           but where the <a>Start of Programme Timecode</a> is
-          not stored, and is not immediately available, the <a>Media Zero Timecode</a>
+          not stored, and is not immediately available, the <a>DAPT Origin Timecode</a>
           can be used to defer synchronisation with the media until
           that media begin timecode is known.
         </p>
-        <p>One approach to deferring synchronisation using <a>Media Zero Timecode</a>
+        <p>One approach to deferring synchronisation using <a>DAPT Origin Timecode</a>
           is as follows, assuming that a legacy source file is being converted
           to a <a>DAPT Document</a> and relates to media with continuous timecode:
         </p>
@@ -2832,12 +2832,12 @@ daptm:descType : string
           <li>Find the earliest begin timecode for an item in the source file
             that will be mapped to a <a>Script Event</a>;</li>
           <li>Create a <a>DAPT Document</a> with
-            a <a>Media Zero Timecode</a> set to that earliest begin timecode;</li>
+            a <a>DAPT Origin Timecode</a> set to that earliest begin timecode;</li>
           <li>For each relevant item in the source file,
             create a <a>Script Event</a> with appropriate
             <a>Begin</a> and <a>End</a> times obtained by converting
             the source file's begin and end timecodes to media time,
-            relative to that <a>Media Zero Timecode</a>,
+            relative to that <a>DAPT Origin Timecode</a>,
             basing elapsed time on the applicable frame rate;</li>
           <li>If using frame-based media time expressions,
             set the <code>ttp:frameRate</code> attribute of
@@ -2847,7 +2847,7 @@ daptm:descType : string
         <p>When the related media's timecode is later dicovered,
           the times of the <a>Script Events</a> can be adjusted so that
           media time zero is coincident with the <a>Start of Programme Timecode</a>,
-          and the <a>Media Zero Timecode</a> can be
+          and the <a>DAPT Origin Timecode</a> can be
           removed or set to the now-known value.
         </p>
         <p class="note">The above algorithm can be used to align the begin times
@@ -2862,11 +2862,11 @@ daptm:descType : string
       <h5>Start of Programme Timecode</h5>
       <p>The optional <dfn>Start of Programme Timecode</dfn> allows a timecode value to be declared
         that corresponds to the beginning of the related media object's programme content.</p>
-      <p >In combination with <a>Media Zero Timecode</a>,
+      <p >In combination with <a>DAPT Origin Timecode</a>,
         the value of <a>Start of Programme Timecode</a> can be used to infer whether or not
         the media times in the <a>DAPT Script</a> are likely to be correctly synchronised with
         the <a>Related Media Object</a>.</p>
-      <p>If both <a>Media Zero Timecode</a> and <a>Start of Programme Timecode</a> are present,
+      <p>If both <a>DAPT Origin Timecode</a> and <a>Start of Programme Timecode</a> are present,
         but their values are different, it is likely that the media times are not
         synchronised with the <a>Related Media Object</a>, since this implies that
         the equivalent time code to zero seconds in media time is not the start of the programme,
@@ -2880,7 +2880,7 @@ daptm:descType : string
 ...
 &lt;head&gt;
 &lt;metadata&gt;
-&lt;daptm:mediaZeroTimecode&gt;10:01:20:12&lt;/daptm:mediaZeroTimecode&gt;
+&lt;daptm:daptOriginTimecode&gt;10:01:20:12&lt;/daptm:daptOriginTimecode&gt;
 &lt;ebuttm:documentStartOfProgramme&gt;10:00:00:00&lt;ebuttm:documentStartOfProgramme&gt;
 &lt;!-- It is likely that this document is 1 minute, 20 seconds and 12 frames too early,
   compared to the related media --&gt;
@@ -2895,7 +2895,7 @@ daptm:descType : string
       </pre>
       <p>If the times of the <a>Script Events</a> are adjusted to bring
         the media time into synchronisation with the <a>Related Media Object</a>,
-        as noted in <a>Media Zero Timecode</a>, the <a>Start of Programme Timecode</a>
+        as noted in <a>DAPT Origin Timecode</a>, the <a>Start of Programme Timecode</a>
         SHOULD NOT be changed, since it is an invariant feature of the <a>Related Media Object</a>,
         and does not describe the times in the <a>DAPT Document</a>.</p>
     </section>
@@ -3469,10 +3469,10 @@ daptm:descType : string
             </td>
           </tr>
           <tr>
-            <td><a href="#mediazerotimecode"><code>#mediaZeroTimecode</code></a></td>
+            <td><a href="#daptorigintimecode"><code>#daptOriginTimecode</code></a></td>
             <td><span class="permitted label">permitted</span></td>
             <td>
-              This is the profile expression of <a href="#media-zero-timecode"></a>.
+              This is the profile expression of <a href="#dapt-origin-timecode"></a>.
             </td>
           </tr>
           <tr>
@@ -3655,12 +3655,12 @@ daptm:descType : string
       </section>
 
       <section>
-        <h3>#mediaZeroTimecode</h3>
-        <p>A <a>transformation processor</a> supports the <code>#mediaZeroTimecode</code> extension if
+        <h3>#daptOriginTimecode</h3>
+        <p>A <a>transformation processor</a> supports the <code>#daptOriginTimecode</code> extension if
           it recognizes and is capable of transforming values of the
-          <code>&lt;</code><a><code>daptm:mediaZeroTimecode</code></a><code>&gt;</code> element.</p>
+          <code>&lt;</code><a><code>daptm:daptOriginTimecode</code></a><code>&gt;</code> element.</p>
   
-        <p>No <a>presentation processor</a> behaviour is defined for the <code>#mediaZeroTimecode</code> extension.</p>
+        <p>No <a>presentation processor</a> behaviour is defined for the <code>#daptOriginTimecode</code> extension.</p>
       </section>
 
       <section>

--- a/index.html
+++ b/index.html
@@ -1036,38 +1036,42 @@
         </section>
 
         <section>
-          <h4>Legacy Metadata</h4>
-          <p>In workflows that create <a>DAPT documents</a> by conversion from legacy formats,
-            there can be cases where data needs to be retained,
-            relating to the conversion process,
-            or parts of the conversion process that cannot easily be completed without
-            additional later steps.
+          <h4>Deferred resolution of timecode-based synchronisation</h4>
+          <p>In workflows that create <a>DAPT documents</a> by conversion from formats
+            that synchronise content using timecode to match time stamps
+            in the <a>related media object</a>,
+            a common issue occurs if the timecode of
+            the beginning of the media is not known at the time of conversion.
           </p>
-          <p>The optional <dfn>Legacy Metadata</dfn> object provides a location within
-            the <a>DAPT document</a> in which such data can be stored.
-            Those items of data can be those defined in this specification,
-            or proprietary extensions;
-            see also <a href="#proprietary-metadata-and-foreign-vocabulary"></a>.
+          <p>The optional <a>Media Zero Timecode</a> and
+            <a>Start of Programme Timecode</a> properties can be used to
+            identify when there is a possible synchronisation error,
+            and to resynchronise the document when all
+            the required information is known.</p>
+          <p>These properties are provided as metadata only and
+            are not intended to be used to perform direct synchronisation offsets
+            during presentation.
           </p>
-          <p>A <a>DAPT Script</a> MAY contain zero or one <a>Legacy Metadata</a> objects.</p>
-          <p>If a <a>Legacy Metadata</a> object is present, the <a>DAPT Document</a> MUST have
+
+          <p>A <a>DAPT Script</a> MAY contain zero or one <a>Media Zero Timecode</a> objects.</p>
+          <p>A <a>DAPT Script</a> MAY contain zero or one <a>Start of Programme Timecode</a> objects.</p>
+          <p>If either a <a>Media Zero Timecode</a> object
+            or a <a>Start of Programme Timecode</a> object is present,
+            the <a>DAPT Document</a> MUST have
             one <code>&lt;head&gt;</code> element child of the <code>&lt;tt&gt;</code> element,
             and that <code>&lt;head&gt;</code> element MUST have
             at least one <code>&lt;metadata&gt;</code> element child.</p>
-          <p>The <a>Legacy Metadata</a> is represented in a <a>DAPT Document</a> by
-            a <code>&lt;daptm:legacy&gt;</code> element present at the path
-            <code>/tt/head/metadata/daptm:legacy</code>.</p>
 
           <section>
             <h5>Media Zero Timecode</h5>
             <p>The optional <dfn>Media Zero Timecode</dfn> allows a timecode value to be declared
               that corresponds to the zero point on the media timeline,
-              that is, the time of a <a>Script Event</a> whose <a>Begin</a> is
+              that is, the time of a hypothetical <a>Script Event</a> whose <a>Begin</a> is
               zero seconds on the media timeline.</p>
-            <p>A <a>Legacy Metadata</a> MAY contain zero or one <a>Media Zero Timecode</a> objects.</p>
+            <p>A <a>DAPT Script</a> MAY contain zero or one <a>Media Zero Timecode</a> objects.</p>
             <p>The <a>Media Zero Timecode</a> object is represented in a <a>DAPT Document</a> by
               a <code>&lt;</code><dfn><code>daptm:mediaZeroTimecode</code></dfn><code>&gt;</code> element present at the path
-              <code>/tt/head/metadata/daptm:legacy/daptm:mediaZeroTimecode</code>,
+              <code>/tt/head/metadata/daptm:mediaZeroTimecode</code>,
               with the following constraints:</p>
             <ul>
               <li>The character content of the element must conform to a <code>clock-time</code>
@@ -1081,9 +1085,7 @@
 ...
 &lt;head&gt;
   &lt;metadata&gt;
-    &lt;daptm:legacy&gt;
-      &lt;daptm:mediaZeroTimecode&gt;10:01:20:12&lt;/daptm:mediaZeroTimecode&gt;
-    &lt;/daptm:legacy&gt;
+    &lt;daptm:mediaZeroTimecode&gt;10:01:20:12&lt;/daptm:mediaZeroTimecode&gt;
   &lt;/metadata&gt;
 &lt;/head&gt;
 &lt;body&gt;
@@ -1093,15 +1095,15 @@
 &lt;/body&gt;
 ...
             </pre>
-            <div class="note">
+            <aside class="example">
               <p>When converting legacy formats that store the equivalent of each Script Event,
                 for example a <a>description</a>, with SMPTE timecodes,
-                but where the timecode corresponding to the beginning of the related media is
+                but where the <a>Start of Programme Timecode</a> is
                 not stored, and is not immediately available, the <a>Media Zero Timecode</a>
                 can be used to defer synchronisation with the media until
                 that media begin timecode is known.
               </p>
-              <p>One approach to resolving this conundrum using <a>Media Zero Timecode</a>
+              <p>One approach to deferring synchronisation using <a>Media Zero Timecode</a>
                 is as follows, assuming that a legacy source file is being converted
                 to a <a>DAPT Document</a> and relates to media with continuous timecode:
               </p>
@@ -1123,12 +1125,60 @@
               </ul>
               <p>When the related media's timecode is later dicovered,
                 the times of the <a>Script Events</a> can be adjusted so that
-                media time zero is coincident with the beginning of the
-                related media, and the <a>Media Zero Timecode</a> can be
+                media time zero is coincident with the <a>Start of Programme Timecode</a>,
+                and the <a>Media Zero Timecode</a> can be
                 removed or set to the now-known value.
               </p>
-            </div>
+              <p class="note">The above algorithm can be used to align the begin times
+                of the <a>DAPT Script</a> and the <a>related media object</a>.
+                It does not address progressive synchronisation errors caused by incorrect frame rates or
+                differing playback rates.
+              </p>
+            </aside>
           </section>
+
+          <section>
+            <h5>Start of Programme Timecode</h5>
+            <p>The optional <dfn>Start of Programme Timecode</dfn> allows a timecode value to be declared
+              that corresponds to the beginning of the related media object's programme content.</p>
+            <p >In combination with <a>Media Zero Timecode</a>,
+              the value of <a>Start of Programme Timecode</a> can be used to infer whether or not
+              the media times in the <a>DAPT Script</a> are likely to be correctly synchronised with
+              the <a>Related Media Object</a>.</p>
+            <p>If both <a>Media Zero Timecode</a> and <a>Start of Programme Timecode</a> are present,
+              but their values are different, it is likely that the media times are not
+              synchronised with the <a>Related Media Object</a>, since this implies that
+              the equivalent time code to zero seconds in media time is not the start of the programme,
+              which is the requirement for correctly synchronised media time.</p>
+            <p>A <a>DAPT Script</a> MAY contain zero or one <a>Start of Programme Timecode</a> objects.</p>
+            <p>The <a>Start of Programme Timecode</a> object is represented in a <a>DAPT Document</a> by
+              a <code>&lt;ebuttm:documentStartOfProgramme&gt;</code> element present at the path
+              <code>/tt/head/metadata/ebuttm:documentStartOfProgramme</code>,
+              with the syntactic constraints as defined in [[EBU-TT-3390]].</p>
+            <pre class="example">
+...
+&lt;head&gt;
+  &lt;metadata&gt;
+    &lt;daptm:mediaZeroTimecode&gt;10:01:20:12&lt;/daptm:mediaZeroTimecode&gt;
+    &lt;ebuttm:documentStartOfProgramme&gt;10:00:00:00&lt;ebuttm:documentStartOfProgramme&gt;
+    &lt;!-- It is likely that this document is 1 minute, 20 seconds and 12 frames too early,
+        compared to the related media --&gt;
+  &lt;/metadata&gt;
+&lt;/head&gt;
+&lt;body&gt;
+  &lt;div xml:id="se1" begin="0s" end="1.8s"&gt;
+    &lt;!-- This script event was generated from a source whose begin timecode was 10:01:20:12 --&gt;
+  &lt;/div&gt;
+&lt;/body&gt;
+...
+            </pre>
+            <p>If the times of the <a>Script Events</a> are adjusted to bring
+              the media time into synchronisation with the <a>Related Media Object</a>,
+              as noted in <a>Media Zero Timecode</a>, the <a>Start of Programme Timecode</a>
+              SHOULD NOT be changed, since it is an invariant feature of the <a>Related Media Object</a>,
+              and does not describe the times in the <a>DAPT Document</a>.</p>
+          </section>
+
         </section>
       </section>
       <section>
@@ -2197,6 +2247,12 @@ daptm:descType : string
               <td><code>http://www.w3.org/ns/ttml/profile/dapt/extension/</code></td>
               <td><em>This specification</em></td>
             </tr>
+            <tr>
+              <td>EBU-TT Metadata</td>
+              <td><code>ebuttm</code></td>
+              <td><code>urn:ebu:tt:metadata</code></td>
+              <td>[[EBU-TT-3390]]</td>
+            </tr>
           </tbody>
         </table>
         <p>
@@ -2207,6 +2263,7 @@ daptm:descType : string
           all undefined names in these namespaces are reserved for future standardization by the W3C.
         </p>
       </section>
+
       <section>
         <h3>Related Media Object (TTML)</h3>
         <p>Within DAPT, the common language terms audio and video are used in the context of a programme.
@@ -2215,14 +2272,14 @@ daptm:descType : string
           provides the media timeline and is the source of the <a>main programme audio</a>,
           and any visual timing references needed when adjusting timings relevant to the video image,
           such as for lip synchronization.</p>
-          <div class="note">
-            <p>A <a>DAPT document</a> can identify the programme acting
-            as the <a>Related Media Object</a> using metadata. For example, it is possible
-            to use the <code>&lt;ebuttm:sourceMediaIdentifier&gt;</code> element defined in [[EBU-TT-3390]].</p>
-            <pre class="xml example" data-include="examples/sourceMediaIdentifier.xml" data-include-format="text"></pre>
-          </div>
-
+        <div class="note">
+          <p>A <a>DAPT document</a> can identify the programme acting
+          as the <a>Related Media Object</a> using metadata. For example, it is possible
+          to use the <code>&lt;ebuttm:sourceMediaIdentifier&gt;</code> element defined in [[EBU-TT-3390]].</p>
+          <pre class="xml example" data-include="examples/sourceMediaIdentifier.xml" data-include-format="text"></pre>
+        </div>
       </section>
+
       <section>
         <h3>Synchronization</h3>
         <p>
@@ -2254,6 +2311,7 @@ daptm:descType : string
           no more than 35ms before the time specified in the <a>DAPT document</a>
           and no more than 45ms after the time specified.</p>
       </section>
+
       <section>
         <h3>Profile Signaling</h3>
         This section defines how a TTML

--- a/index.html
+++ b/index.html
@@ -1034,6 +1034,68 @@
               </div>
             </section>
         </section>
+
+        <section>
+          <h4>Legacy Metadata</h4>
+          <p>In workflows that create <a>DAPT documents</a> by conversion from legacy formats,
+            there can be cases where data needs to be retained,
+            relating to the conversion process,
+            or parts of the conversion process that cannot easily be completed without
+            additional later steps.
+          </p>
+          <p>The optional <dfn>Legacy Metadata</dfn> object provides a location within
+            the <a>DAPT document</a> in which such data can be stored.
+            Those items of data can be those defined in this specification,
+            or proprietary extensions;
+            see also <a href="#proprietary-metadata-and-foreign-vocabulary"></a>.
+          </p>
+          <p>A <a>DAPT Script</a> MAY contain zero or one <a>Legacy Metadata</a> objects.</p>
+          <p>If a <a>Legacy Metadata</a> object is present, the <a>DAPT Document</a> MUST have
+            one <code>&lt;head&gt;</code> element child of the <code>&lt;tt&gt;</code> element,
+            and that <code>&lt;head&gt;</code> element MUST have
+            at least one <code>&lt;metadata&gt;</code> element child.</p>
+          <p>The <a>Legacy Metadata</a> is represented in a <a>DAPT Document</a> by
+            a <code>&lt;daptm:legacy&gt;</code> element present at the path
+            <code>/tt/head/metadata/daptm:legacy</code>.</p>
+
+          <section>
+            <h5>Media Zero Timecode</h5>
+            <p>The optional <dfn>Media Zero Timecode</dfn> allows a timecode value to be declared
+              that corresponds to the zero point on the media timeline,
+              that is, the time of a <a>Script Event</a> whose <a>Begin</a> is
+              zero seconds on the media timeline.</p>
+            <p>A <a>Legacy Metadata</a> MAY contain zero or one <a>Media Zero Timecode</a> objects.</p>
+            <p>The <a>Media Zero Timecode</a> object is represented in a <a>DAPT Document</a> by
+              a <code>&lt;daptm:mediaZeroTimecode&gt;</code> element present at the path
+              <code>/tt/head/metadata/daptm:legacy/daptm:mediaZeroTimecode</code>,
+              with the following constraints:</p>
+            <ul>
+              <li>The character content of the element must conform to a <code>clock-time</code>
+                with a <code>frames</code> component, as defined in <dfn data-cite="ttml2#timing-value-time-expression">&lt;time-expression&gt;</dfn>.</li>
+            </ul>
+            <p class="note">See also <a href="#ttp-framerate"></a>.
+              No mechanism is defined here for declaring a different frame rate for the <a>Media Zero Timecode</a>
+              than is used for other frame-based time expressions.
+            </p>
+            <pre class="example">
+...
+&lt;head&gt;
+  &lt;metadata&gt;
+    &lt;daptm:legacy&gt;
+      &lt;daptm:mediaZeroTimecode&gt;10:01:20:12&lt;/daptm:mediaZeroTimecode&gt;
+    &lt;/daptm:legacy&gt;
+  &lt;/metadata&gt;
+&lt;/head&gt;
+&lt;body&gt;
+  &lt;div xml:id="se1" begin="0s" end="1.8s"&gt;
+    &lt;!-- This script event was generated from a source whose begin timecode was 10:01:20:12 --&gt;
+  &lt;/div&gt;
+&lt;/body&gt;
+...
+
+            </pre>
+          </section>
+        </section>
       </section>
       <section>
         <h3>Character</h3>

--- a/index.html
+++ b/index.html
@@ -1066,7 +1066,7 @@
               zero seconds on the media timeline.</p>
             <p>A <a>Legacy Metadata</a> MAY contain zero or one <a>Media Zero Timecode</a> objects.</p>
             <p>The <a>Media Zero Timecode</a> object is represented in a <a>DAPT Document</a> by
-              a <code>&lt;daptm:mediaZeroTimecode&gt;</code> element present at the path
+              a <code>&lt;</code><dfn><code>daptm:mediaZeroTimecode</code></dfn><code>&gt;</code> element present at the path
               <code>/tt/head/metadata/daptm:legacy/daptm:mediaZeroTimecode</code>,
               with the following constraints:</p>
             <ul>
@@ -3376,6 +3376,13 @@ daptm:descType : string
             </td>
           </tr>
           <tr>
+            <td><a href="#mediazerotimecode"><code>#mediaZeroTimecode</code></a></td>
+            <td><span class="permitted label">permitted</span></td>
+            <td>
+              This is the profile expression of <a href="#media-zero-timecode"></a>.
+            </td>
+          </tr>
+          <tr>
             <td><a href="#onscreen"><code>#onScreen</code></a></td>
             <td><span class="permitted label">permitted</span></td>
             <td>
@@ -3552,6 +3559,15 @@ daptm:descType : string
         the <a><code>ttp:profile</code></a> attribute and
         processor profile inference semantics.
       </aside>
+      </section>
+
+      <section>
+        <h3>#mediaZeroTimecode</h3>
+        <p>A <a>transformation processor</a> supports the <code>#mediaZeroTimecode</code> extension if
+          it recognizes and is capable of transforming values of the
+          <code>&lt;</code><a><code>daptm:mediaZeroTimecode</code></a><code>&gt;</code> element.</p>
+  
+        <p>No <a>presentation processor</a> behaviour is defined for the <code>#mediaZeroTimecode</code> extension.</p>
       </section>
 
       <section>

--- a/index.html
+++ b/index.html
@@ -1035,151 +1035,6 @@
             </section>
         </section>
 
-        <section>
-          <h4>Deferred resolution of timecode-based synchronisation</h4>
-          <p>In workflows that create <a>DAPT documents</a> by conversion from formats
-            that synchronise content using timecode to match time stamps
-            in the <a>related media object</a>,
-            a common issue occurs if the timecode of
-            the beginning of the media is not known at the time of conversion.
-          </p>
-          <p>The optional <a>Media Zero Timecode</a> and
-            <a>Start of Programme Timecode</a> properties can be used to
-            identify when there is a possible synchronisation error,
-            and to resynchronise the document when all
-            the required information is known.</p>
-          <p>These properties are provided as metadata only and
-            are not intended to be used to perform direct synchronisation offsets
-            during presentation.
-          </p>
-
-          <p>A <a>DAPT Script</a> MAY contain zero or one <a>Media Zero Timecode</a> objects.</p>
-          <p>A <a>DAPT Script</a> MAY contain zero or one <a>Start of Programme Timecode</a> objects.</p>
-          <p>If either a <a>Media Zero Timecode</a> object
-            or a <a>Start of Programme Timecode</a> object is present,
-            the <a>DAPT Document</a> MUST have
-            one <code>&lt;head&gt;</code> element child of the <code>&lt;tt&gt;</code> element,
-            and that <code>&lt;head&gt;</code> element MUST have
-            at least one <code>&lt;metadata&gt;</code> element child.</p>
-
-          <section>
-            <h5>Media Zero Timecode</h5>
-            <p>The optional <dfn>Media Zero Timecode</dfn> allows a timecode value to be declared
-              that corresponds to the zero point on the media timeline,
-              that is, the time of a hypothetical <a>Script Event</a> whose <a>Begin</a> is
-              zero seconds on the media timeline.</p>
-            <p>A <a>DAPT Script</a> MAY contain zero or one <a>Media Zero Timecode</a> objects.</p>
-            <p>The <a>Media Zero Timecode</a> object is represented in a <a>DAPT Document</a> by
-              a <code>&lt;</code><dfn><code>daptm:mediaZeroTimecode</code></dfn><code>&gt;</code> element present at the path
-              <code>/tt/head/metadata/daptm:mediaZeroTimecode</code>,
-              with the following constraints:</p>
-            <ul>
-              <li>The character content of the element must conform to a <code>clock-time</code>
-                with a <code>frames</code> component, as defined in <dfn data-cite="ttml2#timing-value-time-expression">&lt;time-expression&gt;</dfn>.</li>
-            </ul>
-            <p class="note">See also <a href="#ttp-framerate"></a>.
-              No mechanism is defined here for declaring a different frame rate for the <a>Media Zero Timecode</a>
-              than is used for other frame-based time expressions.
-            </p>
-            <pre class="example">
-...
-&lt;head&gt;
-  &lt;metadata&gt;
-    &lt;daptm:mediaZeroTimecode&gt;10:01:20:12&lt;/daptm:mediaZeroTimecode&gt;
-  &lt;/metadata&gt;
-&lt;/head&gt;
-&lt;body&gt;
-  &lt;div xml:id="se1" begin="0s" end="1.8s"&gt;
-    &lt;!-- This script event was generated from a source whose begin timecode was 10:01:20:12 --&gt;
-  &lt;/div&gt;
-&lt;/body&gt;
-...
-            </pre>
-            <aside class="example">
-              <p>When converting legacy formats that store the equivalent of each Script Event,
-                for example a <a>description</a>, with SMPTE timecodes,
-                but where the <a>Start of Programme Timecode</a> is
-                not stored, and is not immediately available, the <a>Media Zero Timecode</a>
-                can be used to defer synchronisation with the media until
-                that media begin timecode is known.
-              </p>
-              <p>One approach to deferring synchronisation using <a>Media Zero Timecode</a>
-                is as follows, assuming that a legacy source file is being converted
-                to a <a>DAPT Document</a> and relates to media with continuous timecode:
-              </p>
-              <ul>
-                <li>Find the earliest begin timecode for an item in the source file
-                  that will be mapped to a <a>Script Event</a>;</li>
-                <li>Create a <a>DAPT Document</a> with
-                  a <a>Media Zero Timecode</a> set to that earliest begin timecode;</li>
-                <li>For each relevant item in the source file,
-                  create a <a>Script Event</a> with appropriate
-                  <a>Begin</a> and <a>End</a> times obtained by converting
-                  the source file's begin and end timecodes to media time,
-                  relative to that <a>Media Zero Timecode</a>,
-                  basing elapsed time on the applicable frame rate;</li>
-                <li>If using frame-based media time expressions,
-                  set the <code>ttp:frameRate</code> attribute of
-                  the <code>&lt;tt&gt;</code> element to the applicable frame rate;
-                </li>
-              </ul>
-              <p>When the related media's timecode is later dicovered,
-                the times of the <a>Script Events</a> can be adjusted so that
-                media time zero is coincident with the <a>Start of Programme Timecode</a>,
-                and the <a>Media Zero Timecode</a> can be
-                removed or set to the now-known value.
-              </p>
-              <p class="note">The above algorithm can be used to align the begin times
-                of the <a>DAPT Script</a> and the <a>related media object</a>.
-                It does not address progressive synchronisation errors caused by incorrect frame rates or
-                differing playback rates.
-              </p>
-            </aside>
-          </section>
-
-          <section>
-            <h5>Start of Programme Timecode</h5>
-            <p>The optional <dfn>Start of Programme Timecode</dfn> allows a timecode value to be declared
-              that corresponds to the beginning of the related media object's programme content.</p>
-            <p >In combination with <a>Media Zero Timecode</a>,
-              the value of <a>Start of Programme Timecode</a> can be used to infer whether or not
-              the media times in the <a>DAPT Script</a> are likely to be correctly synchronised with
-              the <a>Related Media Object</a>.</p>
-            <p>If both <a>Media Zero Timecode</a> and <a>Start of Programme Timecode</a> are present,
-              but their values are different, it is likely that the media times are not
-              synchronised with the <a>Related Media Object</a>, since this implies that
-              the equivalent time code to zero seconds in media time is not the start of the programme,
-              which is the requirement for correctly synchronised media time.</p>
-            <p>A <a>DAPT Script</a> MAY contain zero or one <a>Start of Programme Timecode</a> objects.</p>
-            <p>The <a>Start of Programme Timecode</a> object is represented in a <a>DAPT Document</a> by
-              a <code>&lt;ebuttm:documentStartOfProgramme&gt;</code> element present at the path
-              <code>/tt/head/metadata/ebuttm:documentStartOfProgramme</code>,
-              with the syntactic constraints as defined in [[EBU-TT-3390]].</p>
-            <pre class="example">
-...
-&lt;head&gt;
-  &lt;metadata&gt;
-    &lt;daptm:mediaZeroTimecode&gt;10:01:20:12&lt;/daptm:mediaZeroTimecode&gt;
-    &lt;ebuttm:documentStartOfProgramme&gt;10:00:00:00&lt;ebuttm:documentStartOfProgramme&gt;
-    &lt;!-- It is likely that this document is 1 minute, 20 seconds and 12 frames too early,
-        compared to the related media --&gt;
-  &lt;/metadata&gt;
-&lt;/head&gt;
-&lt;body&gt;
-  &lt;div xml:id="se1" begin="0s" end="1.8s"&gt;
-    &lt;!-- This script event was generated from a source whose begin timecode was 10:01:20:12 --&gt;
-  &lt;/div&gt;
-&lt;/body&gt;
-...
-            </pre>
-            <p>If the times of the <a>Script Events</a> are adjusted to bring
-              the media time into synchronisation with the <a>Related Media Object</a>,
-              as noted in <a>Media Zero Timecode</a>, the <a>Start of Programme Timecode</a>
-              SHOULD NOT be changed, since it is an invariant feature of the <a>Related Media Object</a>,
-              and does not describe the times in the <a>DAPT Document</a>.</p>
-          </section>
-
-        </section>
       </section>
       <section>
         <h3>Character</h3>
@@ -2898,6 +2753,152 @@ daptm:descType : string
     <p>
       The security considerations of [[ttml2]] apply.
     </p>
+
+  </section>
+
+  <section class="appendix">
+    <h4>Timecode-related metadata</h4>
+    <p>In workflows that create <a>DAPT documents</a> by conversion from formats
+      that synchronise content using timecode to match time stamps
+      in the <a>related media object</a>,
+      a common issue occurs if the timecode of
+      the beginning of the media is not known at the time of conversion.
+    </p>
+    <p>The optional <a>Media Zero Timecode</a> and
+      <a>Start of Programme Timecode</a> properties can be used to
+      identify when there is a possible synchronisation error,
+      and to resynchronise the document when all
+      the required information is known.</p>
+    <p>These properties are provided as metadata only and
+      are not intended to be used to perform direct synchronisation offsets
+      during presentation.
+    </p>
+
+    <p>A <a>DAPT Script</a> MAY contain zero or one <a>Media Zero Timecode</a> objects.</p>
+    <p>A <a>DAPT Script</a> MAY contain zero or one <a>Start of Programme Timecode</a> objects.</p>
+    <p>If either a <a>Media Zero Timecode</a> object
+      or a <a>Start of Programme Timecode</a> object is present,
+      the <a>DAPT Document</a> MUST have
+      one <code>&lt;head&gt;</code> element child of the <code>&lt;tt&gt;</code> element,
+      and that <code>&lt;head&gt;</code> element MUST have
+      at least one <code>&lt;metadata&gt;</code> element child.</p>
+
+    <section>
+      <h5>Media Zero Timecode</h5>
+      <p>The optional <dfn>Media Zero Timecode</dfn> allows a timecode value to be declared
+        that corresponds to the zero point on the media timeline,
+        that is, the time of a hypothetical <a>Script Event</a> whose <a>Begin</a> is
+        zero seconds on the media timeline.</p>
+      <p>A <a>DAPT Script</a> MAY contain zero or one <a>Media Zero Timecode</a> objects.</p>
+      <p>The <a>Media Zero Timecode</a> object is represented in a <a>DAPT Document</a> by
+        a <code>&lt;</code><dfn><code>daptm:mediaZeroTimecode</code></dfn><code>&gt;</code> element present at the path
+        <code>/tt/head/metadata/daptm:mediaZeroTimecode</code>,
+        with the following constraints:</p>
+      <ul>
+        <li>The character content of the element must conform to a <code>clock-time</code>
+          with a <code>frames</code> component, as defined in <dfn data-cite="ttml2#timing-value-time-expression">&lt;time-expression&gt;</dfn>.</li>
+      </ul>
+      <p class="note">See also <a href="#ttp-framerate"></a>.
+        No mechanism is defined here for declaring a different frame rate for the <a>Media Zero Timecode</a>
+        than is used for other frame-based time expressions.
+      </p>
+      <pre class="example">
+...
+&lt;head&gt;
+&lt;metadata&gt;
+&lt;daptm:mediaZeroTimecode&gt;10:01:20:12&lt;/daptm:mediaZeroTimecode&gt;
+&lt;/metadata&gt;
+&lt;/head&gt;
+&lt;body&gt;
+&lt;div xml:id="se1" begin="0s" end="1.8s"&gt;
+&lt;!-- This script event was generated from a source whose begin timecode was 10:01:20:12 --&gt;
+&lt;/div&gt;
+&lt;/body&gt;
+...
+      </pre>
+      <aside class="example">
+        <p>When converting legacy formats that store the equivalent of each Script Event,
+          for example a <a>description</a>, with SMPTE timecodes,
+          but where the <a>Start of Programme Timecode</a> is
+          not stored, and is not immediately available, the <a>Media Zero Timecode</a>
+          can be used to defer synchronisation with the media until
+          that media begin timecode is known.
+        </p>
+        <p>One approach to deferring synchronisation using <a>Media Zero Timecode</a>
+          is as follows, assuming that a legacy source file is being converted
+          to a <a>DAPT Document</a> and relates to media with continuous timecode:
+        </p>
+        <ul>
+          <li>Find the earliest begin timecode for an item in the source file
+            that will be mapped to a <a>Script Event</a>;</li>
+          <li>Create a <a>DAPT Document</a> with
+            a <a>Media Zero Timecode</a> set to that earliest begin timecode;</li>
+          <li>For each relevant item in the source file,
+            create a <a>Script Event</a> with appropriate
+            <a>Begin</a> and <a>End</a> times obtained by converting
+            the source file's begin and end timecodes to media time,
+            relative to that <a>Media Zero Timecode</a>,
+            basing elapsed time on the applicable frame rate;</li>
+          <li>If using frame-based media time expressions,
+            set the <code>ttp:frameRate</code> attribute of
+            the <code>&lt;tt&gt;</code> element to the applicable frame rate;
+          </li>
+        </ul>
+        <p>When the related media's timecode is later dicovered,
+          the times of the <a>Script Events</a> can be adjusted so that
+          media time zero is coincident with the <a>Start of Programme Timecode</a>,
+          and the <a>Media Zero Timecode</a> can be
+          removed or set to the now-known value.
+        </p>
+        <p class="note">The above algorithm can be used to align the begin times
+          of the <a>DAPT Script</a> and the <a>related media object</a>.
+          It does not address progressive synchronisation errors caused by incorrect frame rates or
+          differing playback rates.
+        </p>
+      </aside>
+    </section>
+
+    <section>
+      <h5>Start of Programme Timecode</h5>
+      <p>The optional <dfn>Start of Programme Timecode</dfn> allows a timecode value to be declared
+        that corresponds to the beginning of the related media object's programme content.</p>
+      <p >In combination with <a>Media Zero Timecode</a>,
+        the value of <a>Start of Programme Timecode</a> can be used to infer whether or not
+        the media times in the <a>DAPT Script</a> are likely to be correctly synchronised with
+        the <a>Related Media Object</a>.</p>
+      <p>If both <a>Media Zero Timecode</a> and <a>Start of Programme Timecode</a> are present,
+        but their values are different, it is likely that the media times are not
+        synchronised with the <a>Related Media Object</a>, since this implies that
+        the equivalent time code to zero seconds in media time is not the start of the programme,
+        which is the requirement for correctly synchronised media time.</p>
+      <p>A <a>DAPT Script</a> MAY contain zero or one <a>Start of Programme Timecode</a> objects.</p>
+      <p>The <a>Start of Programme Timecode</a> object is represented in a <a>DAPT Document</a> by
+        a <code>&lt;ebuttm:documentStartOfProgramme&gt;</code> element present at the path
+        <code>/tt/head/metadata/ebuttm:documentStartOfProgramme</code>,
+        with the syntactic constraints as defined in [[EBU-TT-3390]].</p>
+      <pre class="example">
+...
+&lt;head&gt;
+&lt;metadata&gt;
+&lt;daptm:mediaZeroTimecode&gt;10:01:20:12&lt;/daptm:mediaZeroTimecode&gt;
+&lt;ebuttm:documentStartOfProgramme&gt;10:00:00:00&lt;ebuttm:documentStartOfProgramme&gt;
+&lt;!-- It is likely that this document is 1 minute, 20 seconds and 12 frames too early,
+  compared to the related media --&gt;
+&lt;/metadata&gt;
+&lt;/head&gt;
+&lt;body&gt;
+&lt;div xml:id="se1" begin="0s" end="1.8s"&gt;
+&lt;!-- This script event was generated from a source whose begin timecode was 10:01:20:12 --&gt;
+&lt;/div&gt;
+&lt;/body&gt;
+...
+      </pre>
+      <p>If the times of the <a>Script Events</a> are adjusted to bring
+        the media time into synchronisation with the <a>Related Media Object</a>,
+        as noted in <a>Media Zero Timecode</a>, the <a>Start of Programme Timecode</a>
+        SHOULD NOT be changed, since it is an invariant feature of the <a>Related Media Object</a>,
+        and does not describe the times in the <a>DAPT Document</a>.</p>
+    </section>
 
   </section>
 

--- a/index.html
+++ b/index.html
@@ -1092,8 +1092,40 @@
   &lt;/div&gt;
 &lt;/body&gt;
 ...
-
             </pre>
+            <div class="note">
+              <p>When converting legacy formats that store the equivalent of each Script Event,
+                for example a <a>description</a>, with SMPTE timecodes,
+                but where the timecode corresponding to the beginning of the related media is
+                not stored, and is not immediately available, the <a>Media Zero Timecode</a>
+                can be used to defer synchronisation with the media until
+                that media begin timecode is known.
+              </p>
+              <p>One approach to resolving this conundrum using <a>Media Zero Timecode</a>
+                is as follows, assuming that a legacy source file is being converted
+                to a <a>DAPT Document</a> and relates to media with continuous timecode:
+              </p>
+              <ul>
+                <li>Find the earliest begin timecode for an item in the source file
+                  that will be mapped to a <a>Script Event</a>;</li>
+                <li>Create a <a>DAPT Document</a> with
+                  a <a>Media Zero Timecode</a> set to that earliest begin timecode;</li>
+                <li>For each relevant item in the source file,
+                  create a <a>Script Event</a> with appropriate
+                  <a>Begin</a> and <a>End</a> times obtained by converting
+                  the source file's begin and end timecodes to media time,
+                  relative to that <a>Media Zero Timecode</a>,
+                  basing elapsed time on the applicable frame rate;</li>
+                <li>If using frame-based media time expressions,
+                  set the <code>ttp:frameRate</code> attribute of
+                  the <code>&lt;tt&gt;</code> element to the applicable frame rate;
+                </li>
+              </ul>
+              <p>When the related media's timecode is later dicovered,
+                the times of the <a>Script Events</a> can be adjusted so that
+                the zero points are coincident.
+              </p>
+            </div>
           </section>
         </section>
       </section>

--- a/index.html
+++ b/index.html
@@ -2758,12 +2758,24 @@ daptm:descType : string
 
   <section class="appendix">
     <h4>Timecode-related metadata</h4>
-    <p>In workflows that create <a>DAPT documents</a> by conversion from formats
-      that synchronise content using timecode to match time stamps
-      in the <a>related media object</a>,
-      a common issue occurs if the timecode of
-      the beginning of the media is not known at the time of conversion.
+    <p><a>DAPT Documents</a> express time as <em>media time</em>,
+      which assumes that there is a reference start time (zero) on a media
+      timeline, and a fixed playrate.
+      An alternative scheme that is used in some workflows is to
+      synchronise media components using timecode,
+      time stamps that are applied, for example to each frame of video.
     </p>
+    <p>Workflows that create <a>DAPT documents</a> from
+      resources that use timecode need to map the timecode
+      values onto the <a>DAPT document</a>'s timeline.</p>
+    <p>If this mapping is not correct, presentation of the
+      <a>DAPT Document</a> will not be synchronised with the <a>related media object</a>.
+      In order to achieve correct synchronisation in this scenario,
+      the timecode corresponding to the start of the programme needs to be known.</p>
+    <p>If the start of programme timecode is not known,
+      but timecodes corresponding to <a>Script Events</a> are known,
+      it is still possible to construct a <a>DAPT Document</a>,
+      albeit one whose synchronisation with the related media is uncertain.</p>
     <p>The optional <a>DAPT Origin Timecode</a> and
       <a>Start of Programme Timecode</a> properties can be used to
       identify when there is a possible synchronisation error,
@@ -2771,8 +2783,7 @@ daptm:descType : string
       the required information is known.</p>
     <p>These properties are provided as metadata only and
       are not intended to be used to perform direct synchronisation offsets
-      during presentation.
-    </p>
+      during presentation.</p>
 
     <p>If either a <a>DAPT Origin Timecode</a> object
       or a <a>Start of Programme Timecode</a> object is present,

--- a/index.html
+++ b/index.html
@@ -2761,21 +2761,26 @@ daptm:descType : string
     <p><a>DAPT Documents</a> express time as <em>media time</em>,
       which assumes that there is a reference start time (zero) on a media
       timeline, and a fixed playrate.
-      An alternative scheme that is used in some workflows is to
+      An alternative scheme that is used in some other script formats is to
       synchronise media components using timecode,
-      time stamps that are applied, for example to each frame of video.
+      that match time stamps that are applied,
+      for example to each frame of video.
     </p>
     <p>Workflows that create <a>DAPT documents</a> from
-      resources that use timecode need to map the timecode
+      such timecode-based non-DAPT script formats
+      need to map those timecode
       values onto the <a>DAPT document</a>'s timeline.</p>
     <p>If this mapping is not correct, presentation of the
       <a>DAPT Document</a> will not be synchronised with the <a>related media object</a>.
-      In order to achieve correct synchronisation in this scenario,
-      the timecode corresponding to the start of the programme needs to be known.</p>
-    <p>If the start of programme timecode is not known,
+      A reference timecode that matches a known
+      point on the DAPT document timeline can be used
+      to achieve correct synchronisation, for example
+      the timecode corresponding to the start of the programme,
+      which should match DAPT time zero.</p>
+    <p>In this scenario, if such a reference point is not known,
       but timecodes corresponding to <a>Script Events</a> are known,
       it is still possible to construct a <a>DAPT Document</a>,
-      albeit one whose synchronisation with the related media is uncertain.</p>
+      albeit one whose synchronisation with the related media has not yet been resolved.</p>
     <p>The optional <a>DAPT Origin Timecode</a> and
       <a>Start of Programme Timecode</a> properties can be used to
       identify when there is a possible synchronisation error,
@@ -2783,7 +2788,11 @@ daptm:descType : string
       the required information is known.</p>
     <p>These properties are provided as metadata only and
       are not intended to be used to perform direct synchronisation offsets
-      during presentation.</p>
+      during presentation.
+      In particular, when the related media object uses timecode,
+      the presence of the timecode properties does not mean that
+      the player needs to relate these timecode values with
+      any timecode value embedded in the related media resource.</p>
 
     <p>If either a <a>DAPT Origin Timecode</a> object
       or a <a>Start of Programme Timecode</a> object is present,
@@ -2795,9 +2804,25 @@ daptm:descType : string
     <section>
       <h5>DAPT Origin Timecode</h5>
       <p>The optional <dfn>DAPT Origin Timecode</dfn> allows a timecode value to be declared
-        that corresponds to the zero point on the media timeline,
+        that corresponds to the zero point of the DAPT document timeline,
         that is, the time of a hypothetical <a>Script Event</a> whose <a>Begin</a> is
-        zero seconds on the media timeline.</p>
+        zero seconds.</p>
+      <p>The properties can be used to provide timecodes from
+        the related media object or from any other script format used to produce the DAPT document,
+        and are informational.
+        However, when they are both provided and differ,
+        it is an indication that the DAPT document is not synchronized with
+        the related media object and that processing of the script event begins is needed.
+        To achieve synchronization, the following needs to be done:</p>
+      <ol>
+        <li>The difference
+          <a>DAPT Origin Timecode</a> minus the <a>Start of Programme Timecode</a>
+          is computed as "delta".
+          It may be positive or negative.</li>
+        <li>Each <a>Script Event</a>'s <a>Begin</a> and <a>End</a> value X shall be changed to X + delta.</li>
+        <li>The <a>DAPT Origin Timecode</a> shall be removed or changed to the <a>Start of Programme timecode</a> value
+          so that if this algorithm is run again it will result in delta that is zero.</li>
+      </ol>
       <p>A <a>DAPT Script</a> MAY contain zero or one <a>DAPT Origin Timecode</a> objects.</p>
       <p>The <a>DAPT Origin Timecode</a> object is represented in a <a>DAPT Document</a> by
         a <code>&lt;</code><dfn><code>daptm:daptOriginTimecode</code></dfn><code>&gt;</code> element present at the path
@@ -2810,6 +2835,10 @@ daptm:descType : string
       <p class="note">See also <a href="#ttp-framerate"></a>.
         No mechanism is defined here for declaring a different frame rate for the <a>DAPT Origin Timecode</a>
         than is used for other frame-based time expressions.
+      </p>
+      <p>If the related media object contains a timecode for the video frame
+        synchronized to the origin of the DAPT document timeline,
+        the DAPT origin timecode is equal that timecode. 
       </p>
       <pre class="example">
 ...

--- a/profiles/dapt-content-profile.xml
+++ b/profiles/dapt-content-profile.xml
@@ -91,7 +91,7 @@
     <extension value="required">#xmlLang-root</extension>
     <!-- optional (voluntary) extension support -->
     <extension value="optional">#agent</extension>
-    <extension value="optional">#mediaZeroTimecode</extension>
+    <extension value="optional">#daptOriginTimecode</extension>
     <extension value="optional">#onScreen</extension>
     <extension value="optional">#scriptEventGrouping</extension>
     <extension value="optional">#scriptEventMapping</extension>

--- a/profiles/dapt-content-profile.xml
+++ b/profiles/dapt-content-profile.xml
@@ -91,6 +91,7 @@
     <extension value="required">#xmlLang-root</extension>
     <!-- optional (voluntary) extension support -->
     <extension value="optional">#agent</extension>
+    <extension value="optional">#mediaZeroTimecode</extension>
     <extension value="optional">#onScreen</extension>
     <extension value="optional">#scriptEventGrouping</extension>
     <extension value="optional">#scriptEventMapping</extension>

--- a/profiles/dapt-processor-profile.xml
+++ b/profiles/dapt-processor-profile.xml
@@ -84,6 +84,7 @@
     <!-- required (mandatory) extension support -->
     <extension value="required">#agent</extension>
     <extension value="required">#contentProfiles-root</extension>
+    <extension value="required">#mediaZeroTimecode</extension>
     <extension value="required">#onScreen</extension>
     <extension value="required">#represents</extension>
     <extension value="required">#scriptEventGrouping</extension>

--- a/profiles/dapt-processor-profile.xml
+++ b/profiles/dapt-processor-profile.xml
@@ -84,7 +84,7 @@
     <!-- required (mandatory) extension support -->
     <extension value="required">#agent</extension>
     <extension value="required">#contentProfiles-root</extension>
-    <extension value="required">#mediaZeroTimecode</extension>
+    <extension value="required">#daptOriginTimecode</extension>
     <extension value="required">#onScreen</extension>
     <extension value="required">#represents</extension>
     <extension value="required">#scriptEventGrouping</extension>


### PR DESCRIPTION
Closes #232.

Adds:
1. A metadata object called Media Zero Timecode
2. A metadata object called Start of Programme Timecode
3. An extension feature `#mediaZeroTimecode`, disposition Permitted
4. An example document fragment demonstrating the feature in use
5. An example algorithm for how to use the Media Zero Timecode and Start of Programme Timecode in practice to establish if the document is likely to be correctly synchronised with a related media object whose timings are timecode-based.

Would appreciate review comments from @ewanrsmith - I don't seem to be able to request a review from him.

**Updated 2026-09-25** to remove the `<legacy>` object and add the Start of Programme Timecode object


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/pull/240.html" title="Last updated on Sep 28, 2024, 12:15 AM UTC (c1401ee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/240/f3fb76f...c1401ee.html" title="Last updated on Sep 28, 2024, 12:15 AM UTC (c1401ee)">Diff</a>