### PR TITLE
Switch A/B order in content-descriptor sub-type definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -905,9 +905,9 @@
             </div>
             <p><code>&lt;<a>content-descriptor</a>&gt;</code> has values that are delimiter separated ordered lists
               of tokens.</p>
-            <p>A <code>&lt;<a>content-descriptor</a>&gt;</code> value <em>A</em> is a <dfn data-abbr="sub-type">content descriptor sub-type</dfn>
-              of another <code>&lt;content-descriptor&gt;</code> value <em>B</em> if B's ordered list of <a>descriptor-tokens</a> is
-              present at the beginning of A's ordered list of <a>descriptor-tokens</a>.
+            <p>A <code>&lt;<a>content-descriptor</a>&gt;</code> value <em>B</em> is a <dfn data-abbr="sub-type">content descriptor sub-type</dfn>
+              of another <code>&lt;content-descriptor&gt;</code> value <em>A</em> if A's ordered list of <a>descriptor-tokens</a> is
+              present at the beginning of B's ordered list of <a>descriptor-tokens</a>.
             </p>
             <aside class="example">
               <table class="data">


### PR DESCRIPTION
Closes #253 by making the sub-type definition's A and B terms match those used in the table below.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/pull/260.html" title="Last updated on Oct 8, 2024, 2:11 PM UTC (609b083)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/260/685f0e9...609b083.html" title="Last updated on Oct 8, 2024, 2:11 PM UTC (609b083)">Diff</a>