### PR TITLE
Issue 0274 xml id editorial improvements

### DIFF
--- a/examples/event-desc-descType.xml
+++ b/examples/event-desc-descType.xml
@@ -1,6 +1,6 @@
 ...
   <body>
-    <div begin="10s" end="13s">
+    <div begin="10s" end="13s" xml:id="a123">
       <ttm:desc daptm:descType="pronunciationNote">[oːnʲ]</ttm:desc>
       <p>Eóin looks around at the other assembly members.</p>
     </div>

--- a/examples/event-desc-multiple-descType.xml
+++ b/examples/event-desc-multiple-descType.xml
@@ -1,6 +1,6 @@
 ...
   <body>
-    <div begin="10s" end="13s">
+    <div begin="10s" end="13s" xml:id="a1">
       <ttm:desc daptm:descType="scene">Scene 1</ttm:desc>
       <ttm:desc daptm:descType="plotSignificance">High</ttm:desc>
       <p xml:lang="en">
@@ -10,7 +10,7 @@
         <span>Une femme monte à bord d'un petit bateau à voile.</span>
       </p>
     </div>
-    <div begin="18s" end="20s">
+    <div begin="18s" end="20s" xml:id="a2">
       <ttm:desc daptm:descType="scene">Scene 1</ttm:desc>
       <ttm:desc daptm:descType="plotSignificance">Low</ttm:desc>
       <p xml:lang="en">

--- a/examples/event-desc.xml
+++ b/examples/event-desc.xml
@@ -1,6 +1,6 @@
 ...
   <body>
-    <div begin="10s" end="13s">
+    <div begin="10s" end="13s" xml:id="a1">
       <ttm:desc>Scene 1</ttm:desc>
       <p xml:lang="en">
         <span>A woman climbs into a small sailing boat.</span>
@@ -9,7 +9,7 @@
         <span>Une femme monte à bord d'un petit bateau à voile.</span>
       </p>
     </div>
-    <div begin="18s" end="20s">
+    <div begin="18s" end="20s" xml:id="a2">
       <ttm:desc>Scene 1</ttm:desc>
       <p xml:lang="en">
         <span>The woman pulls the tiller and the boat turns.</span>

--- a/examples/intro-original-language-with-dub-language-and-adaptation.xml
+++ b/examples/intro-original-language-with-dub-language-and-adaptation.xml
@@ -15,7 +15,7 @@
     </metadata>
   </head>
   <body>
-    <div begin="10s" end="13s" ttm:agent="character_1" daptm:onScreen="ON_OFF" daptm:represents="audio.dialogue">
+    <div begin="10s" end="13s" xml:id="d1" ttm:agent="character_1" daptm:onScreen="ON_OFF" daptm:represents="audio.dialogue">
       <p xml:lang="fr" daptm:langSrc="fr">
         <span>Et c'est grâce à ça qu'on va devenir riches.</span>
       </p>

--- a/examples/intro-original-language-with-dub-language.xml
+++ b/examples/intro-original-language-with-dub-language.xml
@@ -15,7 +15,7 @@
     </metadata>
   </head>
   <body>
-    <div begin="10s" end="13s" ttm:agent="character_1" daptm:represents="audio.dialogue">
+    <div begin="10s" end="13s" xml:id="d1" ttm:agent="character_1" daptm:represents="audio.dialogue">
       <p xml:lang="fr" daptm:langSrc="fr"> <!-- original -->
         <span>Et c'est grâce à ça qu'on va devenir riches.</span>
       </p>

--- a/examples/intro-original-language.xml
+++ b/examples/intro-original-language.xml
@@ -15,7 +15,7 @@
     </metadata>
   </head>
   <body>
-    <div begin="10s" end="13s" daptm:represents="audio.dialogue">
+    <div begin="10s" end="13s" xml:id="d1" daptm:represents="audio.dialogue">
       <p ttm:agent="character_1">
         <span>Et c'est grâce à ça qu'on va devenir riches.</span>
       </p>

--- a/examples/intro-script-with-embedded-audio.xml
+++ b/examples/intro-script-with-embedded-audio.xml
@@ -1,5 +1,5 @@
 ...
-    <div begin="25s" end="28s">
+    <div begin="25s" end="28s" xml:id="a3">
       <p>
         <animate begin="0.0s" end="0.3s" tta:gain="1;0.39" fill="freeze"/>
         <animate begin="2.7s" end="3s" tta:gain="0.39;1"/>

--- a/examples/intro-script-with-gain.xml
+++ b/examples/intro-script-with-gain.xml
@@ -4,7 +4,7 @@
   xml:lang="en"
   daptm:langSrc="">
   ...
-    <div begin="25s" end="28s" daptm:represents="visual.nonText">
+    <div begin="25s" end="28s" xml:id="a3" daptm:represents="visual.nonText">
       <p>
         <animate begin="0.0s" end="0.3s" tta:gain="1;0.39" fill="freeze"/>
         <animate begin="2.7s" end="3s" tta:gain="0.39;1"/>

--- a/examples/intro-script-with-speak.xml
+++ b/examples/intro-script-with-speak.xml
@@ -1,5 +1,5 @@
 ...
-    <div begin="18s" end="20s">
+    <div begin="18s" end="20s" xml:id="a2">
       <p>
         <span tta:speak="normal">
           The woman pulls the tiller and the boat turns.</span>

--- a/examples/intro-times-and-text.xml
+++ b/examples/intro-times-and-text.xml
@@ -8,12 +8,12 @@
   daptm:scriptRepresents="visual.nonText visual.text"
   daptm:scriptType="preRecording">
   <body>
-    <div begin="10s" end="13s" daptm:represents="visual.nonText">
+    <div begin="10s" end="13s" xml:id="a1" daptm:represents="visual.nonText">
       <p>
         A woman climbs into a small sailing boat.
       </p>
     </div>
-    <div begin="18s" end="20s" daptm:represents="visual.nonText">
+    <div begin="18s" end="20s" xml:id="a2" daptm:represents="visual.nonText">
       <p>
         The woman pulls the tiller and the boat turns.
       </p>

--- a/examples/intro-times-only.xml
+++ b/examples/intro-times-only.xml
@@ -1,8 +1,8 @@
 ...
   <body daptm:represents="...">
-    <div xml:id="d1" begin="10s" end="13s">
+    <div xml:id="id1" begin="10s" end="13s">
     </div>
-    <div xml:id="d2" begin="18s" end="20s">
+    <div xml:id="id2" begin="18s" end="20s">
     </div>
   </body>
 ...

--- a/examples/intro-top-level.xml
+++ b/examples/intro-top-level.xml
@@ -19,6 +19,14 @@
     </layout>
   </head>
   <body>
-    <!-- Content goes here -->
+    <!-- Content goes here and consists of a div for each Script Event -->
+    <div xml:id="d1" begin="..." end="..." daptm:represents="audio.dialogue">
+      <p>
+        <!-- Text blocks are contained in p elements -->
+      </p>
+      <p xml:lang="fr" daptm:langSrc="en">
+        <!-- Translation text is related to the source language for the translation -->
+      </p>
+    </div>
   </body>
 </tt>

--- a/index.html
+++ b/index.html
@@ -859,6 +859,7 @@
           <p class="ednote">Would it be better to make a "Timed Object" class and subclass Script Event,
             Mixing Instruction and Audio Recording from it?
           </p>
+
           <section>
             <h5>Timing Properties</h5>
             <p>The following <dfn data-lt="timing property|timing properties">timing properties</dfn>
@@ -1045,6 +1046,40 @@
                 </table>
               </div>
             </section>
+
+            <section>
+              <h5>Unique identifiers</h5>
+              <p>Some entities in the data model include unique identifiers.
+                A <dfn>Unique Identifier</dfn> has the following requirements:</p>
+              <ul>
+                <li><p>it is unique within the <a>DAPT Script</a>,
+                  i.e. the value of a <a>Unique Identifier</a> can only
+                  be used one time within the document,
+                  regardless of which specific kind of identifier it is.</p>
+                  <p class="example">If a <a>Character Identifier</a> has the value <code>&quot;abc&quot;</code>
+                    and a <a>Script Event Identifier</a> in the same document has the same value,
+                    that is an error.</p>
+                </li>
+                <li><p>its value has to conform to the requirements of
+                  <code><a data-cite="XML#NT-Name">Name</a></code> as defined by [[XML]]</p>
+                  <div class="note"><p>It cannot begin with
+                    a digit,
+                    a combining diacritical mark (an accent),
+                    or any of the following characters:</p>
+                    <pre><code>    .
+    -
+    &#xB7;  // #xB7
+    &#x203F;  // #x203F
+    &#x2040;  // #x2040</code></pre>
+                  <p>but those characters can be used elsewhere.
+                  </p></div>
+                </li>
+              </ul>
+              <p>A <a>Unique Identifier</a> for an entity is expressed in a <a>DAPT Document</a>
+                by an <code>xml:id</code> attribute on the corresponding element.</p>
+              <p class="note">The formal requirements for the semantics and processing of <code>xml:id</code>
+                are defined in [[xml-id]].</p>
+            </section>
         </section>
 
       </section>
@@ -1054,8 +1089,8 @@
         <p><em>This section is mainly relevant to <a>Dubbing</a> workflows.</em></p>
         <p>A character in the programme can be described using a <dfn>Character</dfn> object which has the following properties: 
           <ul>
-            <li>a mandatory <dfn data-lt="Character Identifier">Identifier</dfn>
-            which is a unique identifier used to reference the character from elsewhere in the document,
+            <li>a mandatory <dfn data-lt="Character Identifier">Character Identifier</dfn>
+            which is a <a>Unique Identifier</a> used to reference the character from elsewhere in the document,
             for example to indicate when a <a>Character</a> participates in a <a>Script Event</a>.</li>
             <li>a mandatory <dfn data-lt="Character Name">Name</dfn> which is the name of the <a>Character</a> in the programme</li>
             <li>an optional <dfn data-lt="Character Talent Name">Talent Name</dfn>, which is the name of the actor speaking dialogue for this <a>Character</a>.</li>
@@ -1149,7 +1184,7 @@
         <h3>Script Event</h3>
         <p>A <dfn>Script Event</dfn> object represents dialogue, on screen text or audio descriptions to be spoken and has the following properties:</p>
         <ul>
-          <li>A mandatory <dfn>Script Event Identifier</dfn> which is unique in the <a>script</a></li>
+          <li>A mandatory <dfn>Script Event Identifier</dfn> which is a <a>Unique Identifier</a>.</li>
           <li>An optional <a>Begin</a> property and an optional <a>End</a> and an optional <a>Duration</a> property
             that together define the <a>Script Event</a>'s time interval in the programme timeline
             <p class="note">Typically <a>Script Events</a> do not overlap in time.


### PR DESCRIPTION
Addresses #274 by ensuring `xml:id` is present in the examples, and by defining a shared property "Unique Identifier" with a summary of the formatting requirements, and referencing that from Character Identifier and Script Event Identifier.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/pull/275.html" title="Last updated on Nov 29, 2024, 12:04 PM UTC (8223e16)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/275/b3b6f70...8223e16.html" title="Last updated on Nov 29, 2024, 12:04 PM UTC (8223e16)">Diff</a>