### PR TITLE
Improve Script Represents in AD examples

### DIFF
--- a/examples/intro-script-with-gain.xml
+++ b/examples/intro-script-with-gain.xml
@@ -1,5 +1,5 @@
 <tt ...
-  daptm:scriptRepresents="visual.nonText visual.text"
+  daptm:scriptRepresents="visual.nonText"
   daptm:scriptType="asRecorded"
   xml:lang="en"
   daptm:langSrc="">

--- a/examples/intro-times-and-text-with-visual-text.xml
+++ b/examples/intro-times-and-text-with-visual-text.xml
@@ -5,15 +5,23 @@
   ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/dapt1.0/content"
   xml:lang="en"
   daptm:langSrc=""
-  daptm:scriptRepresents="visual.nonText"
+  daptm:scriptRepresents="visual.nonText visual.text"
   daptm:scriptType="preRecording">
   <body>
-    <div begin="10s" end="13s" xml:id="a1" daptm:represents="visual.nonText">
+    <div begin="7s" end="8.5s" xml:id="at1"
+         daptm:represents="visual.text.location" daptm:langSrc="en">
+      <p>
+        The Lake District, England
+      </p>
+    </div>
+    <div begin="10s" end="13s" xml:id="a1"
+         daptm:represents="visual.nonText">
       <p>
         A woman climbs into a small sailing boat.
       </p>
     </div>
-    <div begin="18s" end="20s" xml:id="a2" daptm:represents="visual.nonText">
+    <div begin="18s" end="20s" xml:id="a2"
+         daptm:represents="visual.nonText">
       <p>
         The woman pulls the tiller and the boat turns.
       </p>

--- a/index.html
+++ b/index.html
@@ -470,6 +470,24 @@
           data-include="examples/intro-times-and-text.xml"
           data-include-format="text">
         </pre>
+        <p>Audio description content often includes text present in the visual image,
+          for example if the image contains a written sign, a location, etc.
+          The following example demonstrates such a case:
+          <a>Script Represents</a> is extended
+          to show that the <a>script</a>'s contents represent textual visual information
+          in addition to non-textual visual information.
+          Here a more precise value of <a>Represents</a>
+          is specified on the <a>Script Event</a>
+          to reflect that the text is in fact a location,
+          which is allowed because the more precise value is a <a>sub-type</a>
+          of the new value in <a>Script Represents</a>.
+          Finally, since the text has an inherent language, the <a>Text Language Source</a>
+          is set to reflect that language. 
+        </p>
+        <pre class="example"
+          data-include="examples/intro-times-and-text-with-visual-text.xml"
+          data-include-format="text">
+        </pre>
         <p>After creating audio recordings, if not using text to speech, instructions for playback
           mixing can be inserted. For example, The gain of "received" audio can be changed before mixing in
           the audio played from inside the <code>&lt;span&gt;</code> element, smoothly


### PR DESCRIPTION
Addresses #276.

* Remove `visual.text` from `daptm:scriptRepresents` in examples when it is not used
* Add and describe a new example demonstrating the use of content descriptor sub-type, and how `daptm:langSrc` is set when the transcript reflects visual text.

Editorial change only, i.e. non-substantive.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/pull/277.html" title="Last updated on Dec 10, 2024, 5:26 PM UTC (a0056fa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/277/3e51f2a...a0056fa.html" title="Last updated on Dec 10, 2024, 5:26 PM UTC (a0056fa)">Diff</a>