### PR TITLE
updated BBC whitepaper link

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
             title: "BBC R&D White Paper WHP 051. Audio Description: what it is and how it works",
             publisher: "N.E. Tanton, T. Ware and M. Armstrong",
             status: "October 2002 (revised July 2004)",
-            href: "http://www.bbc.co.uk/rd/publications/whitepaper051",
+            href: "https://downloads.bbc.co.uk/rd/pubs/whp/whp-pdf-files/WHP051.pdf",
           },
           "EBU-R37": {
             title: "EBU Recommendation R37-2007. The relative timing of the sound and vision components of a television signal",


### PR DESCRIPTION
publication page seems gone, and could not find new page.
propose to switch into download for now. (please correct if there is a html page to be referred.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/pull/285.html" title="Last updated on Mar 7, 2025, 10:45 AM UTC (463497f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/285/d6ab2fa...463497f.html" title="Last updated on Mar 7, 2025, 10:45 AM UTC (463497f)">Diff</a>