### PR TITLE
Fix BBC R&D White Paper 051 URL to use https

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
             title: "BBC R&D White Paper WHP 051. Audio Description: what it is and how it works",
             publisher: "N.E. Tanton, T. Ware and M. Armstrong",
             status: "October 2002 (revised July 2004)",
-            href: "http://www.bbc.co.uk/rd/publications/whitepaper051",
+            href: "https://www.bbc.co.uk/rd/publications/whitepaper051",
           },
           "EBU-R37": {
             title: "EBU Recommendation R37-2007. The relative timing of the sound and vision components of a television signal",


### PR DESCRIPTION
Purely editorial fix - the current URL does work, via a redirect.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/pull/288.html" title="Last updated on Mar 21, 2025, 11:25 AM UTC (84e052e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/288/37609eb...84e052e.html" title="Last updated on Mar 21, 2025, 11:25 AM UTC (84e052e)">Diff</a>