### PR TITLE
Remove `#xmlId-div` feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -1363,7 +1363,14 @@
           <li>There MUST be one <code>&lt;div&gt;</code> element corresponding to the <a>Script Event</a>,
             with the following constraints:
           <ul>
-            <li>The <code>xml:id</code> attribute MUST be present containing the <a>Script Event Identifier</a>.</li>
+            <li>
+              <p>The <code>xml:id</code> attribute MUST be present containing the
+                <a>Script Event Identifier</a>.</p>
+              <p class="note">See <a href="#handling-div-and-p-elements"></a>
+                for details of how processors deal with <code>&lt;div&gt;</code> elements
+                that do not have an <code>xml:id</code> attribute and are therefore
+                not considered to be <a>Script Events</a>.</p>
+            </li>
             <li>
               <p>The <code>begin</code>, <code>end</code> and <code>dur</code> attributes represent respectively the <a>Begin</a>, <a>End</a> and <a>Duration</a> of the <a>Script Event</a>.</p>
               <p>The <code>begin</code> and <code>end</code> attributes SHOULD be present.
@@ -3804,13 +3811,6 @@ daptm:descType : string
             </td>
           </tr>
           <tr>
-            <td><a href="#extension-xmlId-div"><code>#xmlId-div</code></a></td>
-            <td><span class="required label">required</span></td>
-            <td>
-              This is the profile expression of <a href="#script-event"></a>.
-            </td>
-          </tr>
-          <tr>
             <td><a href="#extension-xmlLang-audio-nonMatching"><code>#xmlLang-audio-nonMatching</code></a></td>
             <td><span class="prohibited label">prohibited</span></td>
             <td>
@@ -4087,15 +4087,6 @@ daptm:descType : string
           <a><code>daptm:langSrc</code></a> attribute.</p>
   
         <p>No <a>presentation processor</a> behaviour is defined for the <code>#textLanguageSource</code> extension.</p>
-      </section>
-
-      <section>
-        <h3 id="extension-xmlId-div">#xmlId-div</h3>
-        <p>A <a>transformation processor</a> supports the <code>#xmlId-div</code> extension if
-          it recognizes and is capable of transforming values of the
-          <code>xml:id</code> attribute on the <code>&lt;div&gt;</code> element.</p>
-  
-        <p>No <a>presentation processor</a> behaviour is defined for the <code>#xmlId-div</code> extension.</p>
       </section>
 
       <section>

--- a/profiles/dapt-content-profile.xml
+++ b/profiles/dapt-content-profile.xml
@@ -88,7 +88,6 @@
     <extension value="required">#scriptRepresents-root</extension>
     <extension value="required">#scriptType-root</extension>
     <extension value="required">#serialization</extension>
-    <extension value="required">#xmlId-div</extension>
     <extension value="required">#xmlLang-root</extension>
     <!-- optional (voluntary) extension support -->
     <extension value="optional">#agent</extension>

--- a/profiles/dapt-processor-profile.xml
+++ b/profiles/dapt-processor-profile.xml
@@ -93,7 +93,6 @@
     <extension value="required">#scriptType-root</extension>
     <extension value="required">#serialization</extension>
     <extension value="required">#textLanguageSource</extension>
-    <extension value="required">#xmlId-div</extension>
     <extension value="required">#xmlLang-root</extension>
     <!-- optional (voluntary) extension support -->
     <extension value="optional">#profile-root</extension>

--- a/substantive-changes-summary.txt
+++ b/substantive-changes-summary.txt
@@ -65,3 +65,5 @@ From FPWD (20230425)
 * Make "Using computed attribute values" normative (#249)
 
 * Rename `#scriptRepresents` to `#scriptRepresents-root` for consistency (#296)
+
+* Remove the `#xmlId-div` feature (#297)


### PR DESCRIPTION
Also add a note under the MUST requirement for `xml:id` on `<div>` elements that are Script Events pointing to the section about handling `<div>` elements that do not have it present.

Closes #297


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/pull/298.html" title="Last updated on Jun 23, 2025, 4:14 PM UTC (e3a66f7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/298/af9c444...e3a66f7.html" title="Last updated on Jun 23, 2025, 4:14 PM UTC (e3a66f7)">Diff</a>