### PR TITLE
Rename `#scriptRepresents` to `#scriptRepresents-root`

### DIFF
--- a/index.html
+++ b/index.html
@@ -3767,7 +3767,7 @@ daptm:descType : string
             </td>
           </tr>
           <tr>
-            <td><a href="#extension-scriptRepresents"><code>#scriptRepresents</code></a></td>
+            <td><a href="#extension-scriptRepresents-root"><code>#scriptRepresents-root</code></a></td>
             <td><span class="required label">required</span></td>
             <td>
               This is the profile expression of <a>Script Represents</a>.
@@ -4008,13 +4008,15 @@ daptm:descType : string
           considered to be a <a>transformation processor</a> for the purpose of this extension.</p>
       </section>
 
+      <!-- include anchor link for old id so that old links go somewhere sensible -->
+      <div id="extension-scriptRepresents"></div>
       <section>
-        <h3 id="extension-scriptRepresents">#scriptRepresents</h3>
-        <p>A <a>transformation processor</a> supports the <code>#scriptRepresents</code> extension if
+        <h3 id="extension-scriptRepresents-root">#scriptRepresents-root</h3>
+        <p>A <a>transformation processor</a> supports the <code>#scriptRepresents-root</code> extension if
           it recognizes and is capable of transforming values of the
           <a><code>daptm:scriptRepresents</code></a> attribute on the <code>&lt;tt&gt;</code> element.</p>
   
-        <p>No <a>presentation processor</a> behaviour is defined for the <code>#scriptRepresents</code> extension.</p>
+        <p>No <a>presentation processor</a> behaviour is defined for the <code>#scriptRepresents-root</code> extension.</p>
 
         <aside class="example">An example of a <a>transformation processor</a> that supports this extension is
           a validating processor that reports an error if the extension is required by a
@@ -4023,7 +4025,7 @@ daptm:descType : string
           <a><code>daptm:scriptRepresents</code></a> attribute on the <code>&lt;tt&gt;</code> element
           or has one whose value is not conformant with the requirements defined herein.</aside>
   
-        <p>No <a>presentation processor</a> behaviour is defined for the <code>#scriptRepresents</code> extension.</p>
+        <p>No <a>presentation processor</a> behaviour is defined for the <code>#scriptRepresents-root</code> extension.</p>
       </section>
 
       <section>

--- a/profiles/dapt-content-profile.xml
+++ b/profiles/dapt-content-profile.xml
@@ -85,7 +85,7 @@
     <!-- required (mandatory) extension support -->
     <extension value="required">#contentProfiles-root</extension>
     <extension value="required">#represents</extension>
-    <extension value="required">#scriptRepresents</extension>
+    <extension value="required">#scriptRepresents-root</extension>
     <extension value="required">#scriptType-root</extension>
     <extension value="required">#serialization</extension>
     <extension value="required">#xmlId-div</extension>

--- a/profiles/dapt-processor-profile.xml
+++ b/profiles/dapt-processor-profile.xml
@@ -89,7 +89,7 @@
     <extension value="required">#onScreen</extension>
     <extension value="required">#represents</extension>
     <extension value="required">#scriptEventGrouping</extension>
-    <extension value="required">#scriptRepresents</extension>
+    <extension value="required">#scriptRepresents-root</extension>
     <extension value="required">#scriptType-root</extension>
     <extension value="required">#serialization</extension>
     <extension value="required">#textLanguageSource</extension>

--- a/substantive-changes-summary.txt
+++ b/substantive-changes-summary.txt
@@ -63,3 +63,5 @@ From FPWD (20230425)
 * At-risk: Script Event Grouping and Script Event Mapping PR-must-have (#239)
 
 * Make "Using computed attribute values" normative (#249)
+
+* Rename `#scriptRepresents` to `#scriptRepresents-root` for consistency (#296)


### PR DESCRIPTION
Closes #296


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/pull/299.html" title="Last updated on Jun 23, 2025, 1:18 PM UTC (e6f0a44)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/299/510a66d...e6f0a44.html" title="Last updated on Jun 23, 2025, 1:18 PM UTC (e6f0a44)">Diff</a>