### PR TITLE
Switch `#scriptEventGrouping` to `#nested-div`

### DIFF
--- a/index.html
+++ b/index.html
@@ -3675,6 +3675,14 @@ daptm:descType : string
             <td>See <a href="#other-ttml2-profile-vocabulary"></a>.</td>
           </tr>
           <tr>
+            <td><dfn data-cite="TTML2#feature-nested-div"><code>#nested-div</code></dfn></td>
+            <td><span class="permitted label">permitted</span></td>
+            <td>
+              This is the profile expression of the permission to nest
+              <code>&lt;div&gt;</code> elements described in <a href="#script-event"></a>.
+            </td>
+          </tr>
+          <tr>
             <td><dfn data-cite="TTML2#feature-permitFeatureWidening"><code>#permitFeatureWidening</code></dfn></td>
             <td><span class="optional label">optional</span></td>
             <td>See <a href="#other-ttml2-profile-vocabulary"></a>.</td>
@@ -3937,14 +3945,6 @@ daptm:descType : string
             </td>
           </tr>
           <tr>
-            <td><a href="#extension-scriptEventGrouping"><code>#scriptEventGrouping</code></a></td>
-            <td><span class="permitted label">permitted</span></td>
-            <td>
-              This is the profile expression of the permission to nest
-              <code>&lt;div&gt;</code> elements described in <a href="#script-event"></a>.
-            </td>
-          </tr>
-          <tr>
             <td><a href="#extension-scriptEventMapping"><code>#scriptEventMapping</code></a></td>
             <td><span class="optional label">optional</span></td>
             <td>
@@ -4155,20 +4155,6 @@ daptm:descType : string
           whose value is not conformant with the requirements defined herein.</aside>
   
         <p>No <a>presentation processor</a> behaviour is defined for the <code>#represents</code> extension.</p>
-      </section>
-
-      <section>
-        <h3 id="extension-scriptEventGrouping">#scriptEventGrouping</h3>
-        <p>A <a>transformation processor</a> supports the <code>#scriptEventGrouping</code> extension if
-          it recognises and is capable of transforming <code>&lt;div&gt;</code> elements
-          that contain <code>&lt;div&gt;</code> elements.</p>
-  
-        <p class="note">Support for the <code>#scriptEventGrouping</code> extension does not imply
-          support for the <a href="#extension-scriptEventMapping"><code>#scriptEventMapping</code></a> extension.</p>
-
-        <p>A <a>presentation processor</a> supports the <code>#scriptEventGrouping</code> extension if
-          it implements presentation semantic support for <code>&lt;div&gt;</code> elements
-          that contain <code>&lt;div&gt;</code> elements.</p>
       </section>
 
       <section>

--- a/profiles/dapt-content-profile.xml
+++ b/profiles/dapt-content-profile.xml
@@ -30,6 +30,7 @@
     <feature value="optional">#gain</feature>
     <feature value="optional">#metadata</feature>
     <feature value="optional">#metadata-item</feature>
+    <feature value="optional">#nested-div</feature>
     <feature value="optional" extends="#metadata">#metadata-version-2</feature>
     <feature value="optional">#pan</feature>
     <feature value="optional">#permitFeatureNarrowing</feature>
@@ -94,7 +95,6 @@
     <extension value="optional">#daptOriginTimecode</extension>
     <extension value="optional">#descType</extension>
     <extension value="optional">#onScreen</extension>
-    <extension value="optional">#scriptEventGrouping</extension>
     <extension value="optional">#scriptEventMapping</extension>
     <extension value="optional">#textLanguageSource</extension>
     <!-- prohibited extension support -->

--- a/profiles/dapt-processor-profile.xml
+++ b/profiles/dapt-processor-profile.xml
@@ -26,6 +26,7 @@
     <feature value="required">#gain</feature>
     <feature value="required">#metadata</feature>
     <feature value="required">#metadata-item</feature>
+    <feature value="required">#nested-div</feature>
     <feature value="required" extends="#metadata">#metadata-version-2</feature>
     <feature value="required">#pan</feature>
     <feature value="required">#pitch</feature>
@@ -88,7 +89,6 @@
     <extension value="required">#descType</extension>
     <extension value="required">#onScreen</extension>
     <extension value="required">#represents</extension>
-    <extension value="required">#scriptEventGrouping</extension>
     <extension value="required">#scriptRepresents-root</extension>
     <extension value="required">#scriptType-root</extension>
     <extension value="required">#serialization</extension>

--- a/substantive-changes-summary.txt
+++ b/substantive-changes-summary.txt
@@ -69,3 +69,5 @@ From FPWD (20230425)
 * Remove the `#xmlId-div` feature (#297)
 
 * Allow Represents to apply to Text (#295)
+
+* Replace the `#scriptEventGrouping` extension feature with the TTML1 feature `#nested-div` (#303)

--- a/substantive-changes-summary.txt
+++ b/substantive-changes-summary.txt
@@ -71,3 +71,5 @@ From FPWD (20230425)
 * Allow Represents to apply to Text (#295)
 
 * Replace the `#scriptEventGrouping` extension feature with the TTML1 feature `#nested-div` (#303)
+
+* Remove the `#xmlId-div` feature (#297)

--- a/substantive-changes-summary.txt
+++ b/substantive-changes-summary.txt
@@ -73,3 +73,5 @@ From FPWD (20230425)
 * Replace the `#scriptEventGrouping` extension feature with the TTML1 feature `#nested-div` (#303)
 
 * Remove the `#xmlId-div` feature (#297)
+
+* Replace the `#scriptEventGrouping` extension feature with the TTML1 feature `#nested-div` (#303)


### PR DESCRIPTION
Closes #303


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/pull/304.html" title="Last updated on Jul 9, 2025, 2:37 PM UTC (a123ed8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/304/3befb22...a123ed8.html" title="Last updated on Jul 9, 2025, 2:37 PM UTC (a123ed8)">Diff</a>