### PR TITLE
added missing bracket

### DIFF
--- a/index.html
+++ b/index.html
@@ -2617,7 +2617,7 @@ daptm:descType : string
         <p>Style references or inline styles MAY be used, using any combination of
         <code>style</code> attributes, 
         <code>&lt;style&gt;</code> elements and
-        inline style attributes as defined in [TTML2] or [TTML-IMSC1.2].</p>
+        inline style attributes as defined in [[TTML2]] or [[TTML-IMSC1.2]].</p>
 
       </section>  <!-- Layout -->
 


### PR DESCRIPTION
as title. spec reference need to be marked up with two brackets.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/dapt/pull/317.html" title="Last updated on Sep 15, 2025, 5:01 PM UTC (4201ddc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/317/56cc47c...himorin:4201ddc.html" title="Last updated on Sep 15, 2025, 5:01 PM UTC (4201ddc)">Diff</a>