### PR TITLE
Change specification status from CR to ED

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 
       var respecConfig = {
       // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
-      specStatus: "CR",
+      specStatus: "ED",
       implementationReportURI: "https://www.w3.org/wiki/TimedText/DAPT_Implementation_Report",
       crEnd: "2025-04-08",
 


### PR DESCRIPTION
closes #306 

For github.io, use specStatus as ED. 
Streamlined publication will be overridden to CRD by GHAction, so leaving crEnd as is (not used for ED).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/pull/323.html" title="Last updated on Sep 26, 2025, 5:50 AM UTC (fd682b4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/323/45f6e98...fd682b4.html" title="Last updated on Sep 26, 2025, 5:50 AM UTC (fd682b4)">Diff</a>