### PR TITLE
Include registry data from external files

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -9,6 +9,7 @@ on:
       - 'examples/**.xml'
       - 'figures/**.svg'
       - 'profiles/**.xml'
+      - 'registries/**.json'
       - 'substantive-changes-summary.txt'
 
 jobs:

--- a/index.html
+++ b/index.html
@@ -1128,14 +1128,17 @@
               values in the <code>content-descriptor</code> registry table, where the
               first additional <code>&lt;<a>descriptor-token</a>&gt;</code> component begins with <code>x-</code>.</p>
 
-              <div class="registry-table-section">
-                <table class="data">
-                  <caption><a>Registry table</a> for the <code>&lt;<a>content-descriptor</a>&gt;</code> component
-                    whose Registry Definition is at <a href="#registry-table-content-descriptor"></a></caption>
-                  <thead data-include="registries/content-descriptor.json" data-oninclude="registryJsonToTableHeaderRow"></thead>
-                  <tbody data-include="registries/content-descriptor.json" data-oninclude="registryJsonToTableBodyRows"></tbody>
-                </table>
-              </div>
+            <div class="registry-table-section">
+              <table class="data">
+                <caption><a>Registry table</a> for the <code>&lt;<a>content-descriptor</a>&gt;</code> component
+                  whose Registry Definition is at <a href="#registry-table-content-descriptor"></a></caption>
+                <thead data-include="registries/content-descriptor.json" data-oninclude="registryJsonToTableHeaderRow"></thead>
+                <tbody data-include="registries/content-descriptor.json" data-oninclude="registryJsonToTableBodyRows"></tbody>
+              </table>
+              <p class="note">The registry entries are available in JSON form in
+                <a class="pp-vcs" href="">the version control system</a> at <code>/registries/content-descriptor.json</code>.
+              </p>
+            </div>
             </section>
 
             <section>
@@ -1787,6 +1790,9 @@ daptm:descType : string
               <thead data-include="registries/descType.json" data-oninclude="registryJsonToTableHeaderRow"></thead>
               <tbody data-include="registries/descType.json" data-oninclude="registryJsonToTableBodyRows"></tbody>
             </table>
+            <p class="note">The registry entries are available in JSON form in
+              <a class="pp-vcs" href="">the version control system</a> at <code>/registries/descType.json</code>.
+            </p>
           </div>
           <p>Valid user-defined values MUST begin with <code>x-</code>.</p>
           <pre class="example"

--- a/index.html
+++ b/index.html
@@ -12,6 +12,40 @@
           element.href=config.github.repoURL)
       }
 
+      function registryJsonToTableHeaderRow(utils, content, url) {
+        const reg_data = JSON.parse(content);
+        let html_content = "";
+
+        reg_data["columns"].forEach((column) => {
+          html_content += "<th>";
+          if (column.isKey && !column.isType) html_content += `<code><a>${column.header}</a></code>`;
+          else if (column.isKey && column.isType) html_content += `<code>&lt;<a>${column.header}</a>&gt;</code>`;
+          else html_content += column.header;
+          html_content += "</th>";
+        });
+        
+        return html_content;
+      }
+
+      function registryJsonToTableBodyRows(utils, content, url) {
+        const reg_data = JSON.parse(content);
+        let html_content = "";
+        
+        reg_data.values.forEach((value) => {
+          html_content += "<tr>"
+          reg_data["columns"].forEach((column) => {
+            if (column.isKey) {
+              html_content += `<td><code>${value[column.rowKey]}</code></td>`;
+            } else {
+              html_content += `<td>${value[column.rowKey]}</td>`;
+            };
+          });
+          html_content += "</tr>"
+        });
+
+        return html_content;
+      }
+
       var respecConfig = {
       // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
       specStatus: "ED",
@@ -1098,84 +1132,8 @@
                 <table class="data">
                   <caption><a>Registry table</a> for the <code>&lt;<a>content-descriptor</a>&gt;</code> component
                     whose Registry Definition is at <a href="#registry-table-content-descriptor"></a></caption>
-                  <thead>
-                    <th><code>&lt;<a>content-descriptor</a>&gt;</code></th>
-                    <th>Status</th>
-                    <th>Description</th>
-                    <th>Example usage</th>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <td><code>audio</code></td>
-                      <td>Provisional</td>
-                      <td>Indicates that the DAPT content represents any part of the audio programme.</td>
-                      <td>Dubbing, translation and hard of hearing subtitles and captions, pre- and post- production scripts</td>
-                    </tr>
-                    <tr>
-                      <td><code>audio.dialogue</code></td>
-                      <td>Provisional</td>
-                      <td>Indicates that the DAPT content represents verbal communication in the audio programme,
-                        for example, a spoken conversation.</td>
-                      <td>Dubbing, translation and hard of hearing subtitles and captions, pre- and post- production scripts</td>
-                    </tr>
-                    <tr>
-                      <td><code>audio.nonDialogueSounds</code></td>
-                      <td>Provisional</td>
-                      <td>Indicates that the DAPT content represents a part of
-                        the audio programme corresponding to sounds that are not verbal communication,
-                        for example, significant sounds, such as a door being slammed in anger.
-                      </td>
-                      <td>Translation and hard of hearing subtitles and captions, pre- and post- production scripts</td>
-                    </tr>
-                    <tr>
-                      <td><code>visual</code></td>
-                      <td>Provisional</td>
-                      <td>Indicates that the DAPT content represents any part of the visual image of the programme.</td>
-                      <td>Audio Description</td>
-                    </tr>
-                    <tr>
-                      <td><code>visual.dialogue</code></td>
-                      <td>Provisional</td>
-                      <td>Indicates that the DAPT content represents verbal communication,
-                        within the visual image of the programme,
-                        for example, a signed conversation.</td>
-                      <td>Dubbing or Audio Description, translation and hard of hearing subtitles and captions, pre- and post- production scripts</td>
-                    </tr>
-                    <tr>
-                      <td><code>visual.nonText</code></td>
-                      <td>Provisional</td>
-                      <td>Indicates that the DAPT content represents non-textual
-                        parts of the visual image of the programme,
-                        for example, a significant object in the scene.</td>
-                      <td>Audio Description</td>
-                    </tr>
-                    <tr>
-                      <td><code>visual.text</code></td>
-                      <td>Provisional</td>
-                      <td>Indicates that the DAPT content represents textual
-                        content in the visual image of the programme,
-                        for example, a signpost, a clock, a newspaper headline, an instant message etc.</td>
-                      <td>Audio Description</td>
-                    </tr>
-                    <tr>
-                      <td><code>visual.text.title</code></td>
-                      <td>Provisional</td>
-                      <td>A <a>sub-type</a> of <code>visual.text</code> where the text is the title of the related media.</td>
-                      <td>Audio Description</td>
-                    </tr>
-                    <tr>
-                      <td><code>visual.text.credit</code></td>
-                      <td>Provisional</td>
-                      <td>A <a>sub-type</a> of <code>visual.text</code> where the text is a credit, e.g. the name of an actor.</td>
-                      <td>Audio Description</td>
-                    </tr>
-                    <tr>
-                      <td><code>visual.text.location</code></td>
-                      <td>Provisional</td>
-                      <td>A <a>sub-type</a> of <code>visual.text</code> where the text indicates the location where the content is occurring.</td>
-                      <td>Audio Description</td>
-                    </tr>
-                  </tbody>
+                  <thead data-include="registries/content-descriptor.json" data-oninclude="registryJsonToTableHeaderRow"></thead>
+                  <tbody data-include="registries/content-descriptor.json" data-oninclude="registryJsonToTableBodyRows"></tbody>
                 </table>
               </div>
             </section>
@@ -1826,32 +1784,8 @@ daptm:descType : string
             <table class="data">
               <caption><a>Registry table</a> for the <code>daptm:descType</code> attribute
                 whose Registry Definition is at <a href="#registry-table-descType"></a></caption>
-              <thead>
-                <th><code>daptm:descType</code></th>
-                <th>Status</th>
-                <th>Description</th>
-                <th>Notes</th>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>pronunciationNote</td>
-                  <td>Provisional</td>
-                  <td>Notes for how to pronounce the content.</td>
-                  <td></td>
-                </tr>
-                <tr>
-                  <td>scene</td>
-                  <td>Provisional</td>
-                  <td>Contains a scene identifier</td>
-                  <td></td>
-                </tr>
-                <tr>
-                  <td>plotSignificance</td>
-                  <td>Provisional</td>
-                  <td>Defines a measure of how significant the content is to the plot.</td>
-                  <td>Contents are undefined and may be low, medium or high, or a numerical scale.</td>
-                </tr>
-              </tbody>
+              <thead data-include="registries/descType.json" data-oninclude="registryJsonToTableHeaderRow"></thead>
+              <tbody data-include="registries/descType.json" data-oninclude="registryJsonToTableBodyRows"></tbody>
             </table>
           </div>
           <p>Valid user-defined values MUST begin with <code>x-</code>.</p>

--- a/registries/README.md
+++ b/registries/README.md
@@ -1,0 +1,62 @@
+# Registry JSON files
+
+This directory includes JSON files containing the Registry table data for
+the registries defined in DAPT.
+
+## Structure
+
+The JSON has the following structure:
+
+```json
+{
+    "columns": [
+        {
+            "header": "some human readable thing",
+            "isKey": true,
+            "rowKey": "value",
+            "isType": false
+        },
+        {
+            "header": "some other human readable thing",
+            "rowKey": "foo"
+        }
+    ],
+    "values": [
+        {
+            "value": "first value",
+            "foo": "bar1"
+        },
+        {
+            "value": "second value",
+            "foo": "bar2"
+        }
+    ]
+}
+```
+
+The `header` in each object in `columns` is a human readable column header.
+
+The `rowKey` in each object in `columns` is used as the key in each entry in
+the `values` array so that the header text does not need
+to be reproduced in every entry, but a simpler string can be used instead.
+
+For each object in the `columns` array there MUST be a corresponding
+key and value in every object in the `values` array.
+Within the DAPT specification those values are mapped into the relevant
+registry table.
+Additional keys and values in a `values` array object, where the key does not
+match a `rowKey` will not be reflected in the specification.
+
+If `isKey` is `true` that indicates that the column contains a registry key.
+
+If `isType` is `true` and `isKey` is `true` that indicates that the column
+header is a data type, which will be formatted surrounded by angle brackets
+as per the TTML document conventions.
+
+## Use of the registry JSON files in DAPT implementations
+
+Implementations can check find the set of permitted values in DAPT documents
+by iterating through the `values` array, and getting the objects whose
+key(s) is/are identified in `columns` with `isKey: true`.
+
+The `status` of each value is also relevant to identify Deprecated values.

--- a/registries/content-descriptor.json
+++ b/registries/content-descriptor.json
@@ -1,0 +1,84 @@
+{
+    "columns": [
+        {
+            "header": "content-descriptor",
+            "isKey": true,
+            "rowKey": "value",
+            "isType": true
+        },
+        {
+            "header": "Status",
+            "rowKey": "status"
+        },
+        {
+            "header": "Description",
+            "rowKey": "description"
+        },
+        {
+            "header": "Example usage",
+            "rowKey": "example_usage"
+        }
+    ],
+    "values": [
+        {
+            "value": "audio",
+            "status": "Provisional",
+            "description": "Indicates that the DAPT content represents any part of the audio programme.",
+            "example_usage": "Dubbing, translation and hard of hearing subtitles and captions, pre- and post- production scripts"
+        },
+        {
+            "value": "audio.dialogue",
+            "status": "Provisional",
+            "description": "Indicates that the DAPT content represents verbal communication in the audio programme, for example, a spoken conversation.",
+            "example_usage": "Dubbing, translation and hard of hearing subtitles and captions, pre- and post- production scripts"
+        },
+        {
+            "value": "audio.nonDialogueSounds",
+            "status": "Provisional",
+            "description": "Indicates that the DAPT content represents a part of the audio programme corresponding to sounds that are not verbal communication, for example, significant sounds, such as a door being slammed in anger.",
+            "example_usage": "Translation and hard of hearing subtitles and captions, pre- and post- production scripts"
+        },
+        {
+            "value": "visual",
+            "status": "Provisional",
+            "description": "Indicates that the DAPT content represents any part of the visual image of the programme.",
+            "example_usage": "Audio Description"
+        },
+        {
+            "value": "visual.dialogue",
+            "status": "Provisional",
+            "description": "Indicates that the DAPT content represents verbal communication, within the visual image of the programme, for example, a signed conversation.",
+            "example_usage": "Dubbing or Audio Description, translation and hard of hearing subtitles and captions, pre- and post- production scripts"
+        },
+        {
+            "value": "visual.nonText",
+            "status": "Provisional",
+            "description": "Indicates that the DAPT content represents non-textual parts of the visual image of the programme, for example, a significant object in the scene.",
+            "example_usage": "Audio Description"
+        },
+        {
+            "value": "visual.text",
+            "status": "Provisional",
+            "description": "Indicates that the DAPT content represents textual content in the visual image of the programme, for example, a signpost, a clock, a newspaper headline, an instant message etc.",
+            "example_usage": "Audio Description"
+        },
+        {
+            "value": "visual.text.title",
+            "status": "Provisional",
+            "description": "A <a>sub-type</a> of <code>visual.text</code> where the text is the title of the related media.",
+            "example_usage": "Audio Description"
+        },
+        {
+            "value": "visual.text.credit",
+            "status": "Provisional",
+            "description": "A <a>sub-type</a> of <code>visual.text</code> where the text is a credit, e.g. the name of an actor.",
+            "example_usage": "Audio Description"
+        },
+        {
+            "value": "visual.text.location",
+            "status": "Provisional",
+            "description": "A <a>sub-type</a> of <code>visual.text</code> where the text indicates the location where the content is occurring.",
+            "example_usage": "Audio Description"
+        }
+    ]
+}

--- a/registries/descType.json
+++ b/registries/descType.json
@@ -1,0 +1,42 @@
+{
+    "columns": [
+        {
+            "header": "daptm:descType",
+            "isKey": true,
+            "rowKey": "value",
+            "isType": false
+        },
+        {
+            "header": "Status",
+            "rowKey": "status"
+        },
+        {
+            "header": "Description",
+            "rowKey": "description"
+        },
+        {
+            "header": "Notes",
+            "rowKey": "notes"
+        }
+    ],
+    "values": [
+        {
+            "value": "pronunciationNote",
+            "status": "Provisional",
+            "description": "Notes for how to pronounce the content.",
+            "notes": ""
+        },
+        {
+            "value": "scene",
+            "status": "Provisional",
+            "description": "Contains a scene identifier",
+            "notes": ""
+        },
+        {
+            "value": "plotSignificance",
+            "status": "Provisional",
+            "description": "Defines a measure of how significant the content is to the plot.",
+            "notes": "Contents are undefined and may be low, medium or high, or a numerical scale."
+        }
+    ]
+}


### PR DESCRIPTION
Use Respec's `data-oninclude` mechanism to write the table header and table body rows, using functions added for the purpose. This allows the table caption to be specified locally without being in the data file.

Add `registries/` directory and the two registry data files as JSON. Add a `README.md` file to explain the JSON structure.

Move the `<content-descriptor>` and `daptm:descType` registry entries into JSON files and describe their location in the specification so that implementers can find them.

Closes #325.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/pull/326.html" title="Last updated on Oct 7, 2025, 5:21 PM UTC (75a732a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/326/b86ecfb...75a732a.html" title="Last updated on Oct 7, 2025, 5:21 PM UTC (75a732a)">Diff</a>