### PR TITLE
Permit empty `daptm:langSrc` and make it the default

### DIFF
--- a/index.html
+++ b/index.html
@@ -1479,10 +1479,11 @@
                   </p>
                 </aside>
               </li>
-              <li id="lang-src-should-not-be-und">The computed value of <a><code>daptm:langSrc</code></a> SHOULD NOT be <code>und</code>.
+              <li id="lang-src-should-not-be-und">The computed value of <a><code>daptm:langSrc</code></a>
+                SHOULD NOT be the empty string or <code>und</code>.
                   <aside class="note">
                     <p>A document that does not specify the <a><code>daptm:langSrc</code></a> attribute at all
-                      has the default value <code>und</code> which
+                      has the default value of the empty string which
                       implies that the language of the content represented by the <a>Text</a>
                       has not been determined.</p>
                   </aside>
@@ -1536,11 +1537,15 @@
           <p>The <dfn>Text Language Source</dfn> property is an annotation indicating the source language of
             a <a>Text</a> object, if applicable, or that the source content had no inherent language:</p>
           <ul>
+            <li>If it is empty, the <a>Text</a> represents content without an inherent language,
+            such as untranslated descriptions of a visual scene or
+            captions representing non-dialogue sounds.</li>
             <li>If it has a value that does not represent a language,
-              such as <code>und</code> or <code>zxx</code>,
+              such as the empty string, <code>und</code> or <code>zxx</code>,
               the <a>Text</a> is <a>Original</a>.
               <aside class="note">
-                The value <code>und</code> represents content whose inherent language has not yet been determined.
+                The empty string should be used instead of the value <code>und</code>
+                to represent content whose inherent language has not yet been determined.
               </aside>
               <aside class="note">
                 <p>The value <code>zxx</code> represents content without an inherent language,
@@ -1572,14 +1577,16 @@
           <div class="exampleInner">
             <pre class="language-abnf">
 daptm:langSrc
-: &lt;language-identifier&gt;
+: &lt;empty-string&gt; | &lt;language-identifier&gt;
+
+&lt;empty-string&gt;
+: ""                    # default
 
 &lt;language-identifier&gt;   # well-formed BCP-47 language tag
             </pre>
           </div>
           <ul>
-            <li>The value MUST be a well-formed language identifier as defined by [[BCP47]].</li>
-            <li>The default value is <code>und</code>.</li>
+            <li>The value MUST be an empty string or a well-formed language identifier as defined by [[BCP47]].</li>
             <li>It <em>applies</em> to <code>&lt;p&gt;</code> and <code>&lt;span&gt;</code> elements.</li>
             <li>It MAY be specified on the following elements:
               <code>&lt;tt&gt;</code>,
@@ -1605,7 +1612,7 @@ daptm:langSrc
                   linguistic content then it indicates that the <a>Text</a> is <a>Original</a>.
                   Example values in this category are:
                   <ul>
-                    <li><code>und</code> for content whose language has not been determined;</li>
+                    <li>An empty string for content whose language has not been determined;</li>
                     <li><code>zxx</code> for content without an inherent language.</li>
                   </ul>
                 </li>

--- a/substantive-changes-summary.txt
+++ b/substantive-changes-summary.txt
@@ -79,4 +79,4 @@ From CRS (20250311)
 
 * Clarify which elements the `src` attribute can reference using a fragment identifier, and align with TTML2 (#312)
 
-* Prohibit empty `daptm:langSrc`, set default to `und` (#320, #321)
+* Allow for non-linguistic language codes in `daptm:langSrc` (#320, #321, #330)

--- a/xml-schemas/dapt-datatypes.xsd
+++ b/xml-schemas/dapt-datatypes.xsd
@@ -19,4 +19,7 @@
         </xs:annotation>
         <xs:restriction base="xs:string"/>
     </xs:simpleType>
+    <xs:simpleType name="emptyValueType">
+        <xs:restriction base="xs:normalizedString"><xs:enumeration value=""/></xs:restriction>
+    </xs:simpleType>
 </xs:schema>

--- a/xml-schemas/dapt-metadata.xsd
+++ b/xml-schemas/dapt-metadata.xsd
@@ -11,7 +11,11 @@
                <xs:restriction base="xs:string"/>
           </xs:simpleType>
      </xs:attribute>
-     <xs:attribute name="langSrc" type="xs:language"/>
+     <xs:attribute name="langSrc">
+          <xs:simpleType>
+               <xs:union memberTypes="daptd:emptyValueType xs:language"></xs:union>
+          </xs:simpleType>
+     </xs:attribute>
      <xs:attribute name="onScreen">
           <xs:simpleType>
                <xs:restriction base="xs:token">


### PR DESCRIPTION
Reverts the change in #322 that prohibited empty `daptm:langSrc` and changed its default to `und`, while keeping the parts that allow in general for non-linguistic language code values.

Closes #330.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/pull/331.html" title="Last updated on Nov 20, 2025, 11:52 AM UTC (60f3669)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/331/e3f13b3...60f3669.html" title="Last updated on Nov 20, 2025, 11:52 AM UTC (60f3669)">Diff</a>