### PR TITLE
Add section about IMSC compatibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -2500,7 +2500,22 @@ daptm:descType : string
           </ul>
         </section>
 
+        <section id="imsc-signaling">
+          <h4>Signaling conformance to IMSC</h4>
+
+          <p>A document conforming to this specification and to [[ttml-imsc]]
+            signals its conformance to both by
+            including in the <code>ttp:contentProfiles</code> attribute
+            both the designators for <a>DAPT 1.0 Content Profile</a> and
+            <!-- [=IMSC Text Profile=] -->
+            <a data-cite="ttml-imsc1.3#dfn-text-profile">IMSC Text Profile</a>,
+            in addition to any other profiles to which the document conforms.
+          </p>
+
+          <p class="note">See also <a href="#imsc-interop"></a>.</p>
+        </section>
       </section>
+
       <section>
         <h3>Timing constraints</h3>
         <p>Within a DAPT Script, the following constraints apply in relation to time attributes and time expressions:</p>
@@ -4500,6 +4515,85 @@ daptm:descType : string
           <p>The <a>key</a> values for this <a>registry table</a> MUST NOT begin with <code>x-</code> which is reserved for user extensions.</p>
         </section>
       </section>
+  </section>
+
+  <section id='interop-examples' class="appendix informative">
+    <h2>Compatibility with other TTML-based specifications</h2>
+
+    <section class='appendix'>
+      <h3>Overview</h3>
+
+      <p>This specification is designed to be compatible with [[ttml-imsc1]]
+        and other profiles of [[ttml2]].
+        Specifically, by selecting a subset of the features and
+        extensions defined in this specification,
+        it is possible to create a document that:conforms to [[ttml-imsc1]],
+        and is also a <a>DAPT Document</a>.</p>
+    </section>
+
+    <section id="imsc-interop" class="appendix">
+      <h3>IMSC Text Profile</h3>
+
+      <p>It is possible for a <a>DAPT Document</a> also to be an
+        <!-- [=IMSC Text Profile=] -->
+        <a data-cite="ttml-imsc1.3#dfn-text-profile">IMSC Text Profile</a>
+        document by meeting the conformance requirements
+        of both.</p>
+
+      <p>The DAPT <a>#serialization</a> feature
+        is effectively a superset of the
+        <a data-cite="ttml-imsc1.3#document-encoding">IMSC document encoding</a>
+        constraints, so a conformant <a>DAPT Document</a> meets the
+        encoding constraints of IMSC.
+      </p>
+
+      <p>Both IMSC Text Profile and DAPT allow
+        vocabulary defined by other profiles,
+        for example metadata, to be present within a <a>Document Instance</a>,
+        so vocabulary defined in IMSC can be used in a
+        <a>DAPT Document</a>, though a processor not intended to
+        process both profiles might prune <a>unrecognised vocabulary</a>
+        present outside <code>metadata</code> elements.
+      </p>
+
+      <p>IMSC imposes constraints on <a href="ttml-imsc#resources-constraints">#resources</a>
+        that prohibit embedded audio within <a>Document Instances</a>.
+        A <a>DAPT Document</a> that uses this feature can therefore
+        not be a conformant
+        <!-- [=IMSC Text Profile=] -->
+        <a data-cite="ttml-imsc1.3#dfn-text-profile">IMSC Text Profile</a> document.</p>
+
+      <section>
+        <h4>Using DAPT metadata in subtitle and caption workflows</h4>
+
+        <p>Subtitle and caption authoring workflows that begin with a
+          [[dapt]] transcription stage, and optional translation stages,
+          can use the DAPT metadata to direct the
+          production or presentation of IMSC Text profile documents.
+          For example:</p>
+
+        <ul>
+          <li>speaker (<a>Character</a>) data can be used to apply styling or to insert content 
+            that indicates changes of speaker, such as prefixing text with
+            commonly used change of speaker symbols, or with the
+            name of the speaker.</li>
+          <li>representation data (i.e. metadata that <a href="#dfn-content-descriptor">describes what content</a> in
+            the <a data-cite="ttml-imsc1.3#dfn-related-video-object">Related Video Object</a>
+            the text content represents) can be
+            used to filter or select sub-sets of the text content, for example
+            to include or exclude non-dialogue sound captions.</li>
+          <li>language and <a>Text language source</a> metadata can be used to generate
+            translation subtitle documents by selecting <a>Text</a> that has been
+            translated into the desired language.</li>
+          <li>language and <a>Text language source</a> metadata can be used to identify
+            subtitles that are <a>Translations</a>, either to flag as
+            <a href="ttml-imsc#forced-content">forced content</a> or to trigger
+            text to speech for subtitles that are translated, where appropriate
+            to meet the user's preferences, a practice known as
+            "spoken subtitles".</li>
+        </ul>
+      </section>
+    </section>
   </section>
 
   <section class="appendix">

--- a/index.html
+++ b/index.html
@@ -4577,7 +4577,8 @@ daptm:descType : string
             that indicates changes of speaker, such as prefixing text with
             commonly used change of speaker symbols, or with the
             name of the speaker.</li>
-          <li>representation data (i.e. metadata that <a href="#dfn-content-descriptor">describes what content</a> in
+          <li>representation data (i.e. metadata that
+            <a href="#dfn-content-descriptor">describes what content</a> in
             the <a data-cite="ttml-imsc1.3#dfn-related-video-object">Related Video Object</a>
             the text content represents) can be
             used to filter or select sub-sets of the text content, for example

--- a/index.html
+++ b/index.html
@@ -789,7 +789,7 @@
           It has properties and objects defined in the following sections:
           <a>Script Represents</a>, <a>Script Type</a>, <a>Default Language</a>, <a>Text Language Source</a>, <a>Script Events</a>
           and, for <a>Dubbing Scripts</a>, <a>Characters</a>.</p>
-        <p>A <dfn>DAPT Document</dfn> is a [[TTML2]] <a>timed text content document instance</a> representing a <a>DAPT Script</a>.
+        <p>A <dfn class="export">DAPT Document</dfn> is a [[TTML2]] <a>timed text content document instance</a> representing a <a>DAPT Script</a>.
           A <a>DAPT Document</a> has the structure and constraints defined in this and the following sections.</p>
         <p class="note">
           A [[TTML2]] <a>timed text content document instance</a> has
@@ -3072,7 +3072,7 @@ daptm:descType : string
 
     <p>Notwithstanding the XML-related considerations of [[ttml2]],
       <a>DAPT documents</a> are required by the mandatory
-      <a href="#extension-serialization"><code>#serialization</code></a>
+      <a><code>#serialization</code></a>
       extension feature to avoid 
       declaring or referencing a Document Type Declaration and to avoid using
       the [[xml]] entity expansion mechanism.
@@ -3990,7 +3990,7 @@ daptm:descType : string
             </td>
           </tr>
           <tr>
-            <td><a href="#extension-serialization"><code>#serialization</code></a></td>
+            <td><a><code>#serialization</code></a></td>
             <td><span class="required label">required</span></td>
             <td>
               This is the profile expression of <a href="#document-encoding"></a>.
@@ -4237,7 +4237,8 @@ daptm:descType : string
 
       <section>
         <h3 id="extension-serialization">#serialization</h3>
-        <p>A serialized document that is valid with respect to the <code>#serialization</code>
+        <p>A serialized document that is valid with respect to the
+          <dfn class="export" data-lt="#serialization|DAPT#serialization"><code>#serialization</code></dfn>
           extension is
           an XML 1.0 [[xml]] document encoded using
           UTF-8 character encoding as specified in [[UNICODE]],


### PR DESCRIPTION
Addresses #332.

* Export some terms so they can be used in other specs e.g. IMSC
* Add a section on signalling conformance to IMSC
* Add a section on IMSC compatibility, including a subsection on how DAPT metadata can be used in the subtitle production workflow.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/pull/333.html" title="Last updated on Jan 19, 2026, 3:05 PM UTC (52a6488)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt/333/e50c715...52a6488.html" title="Last updated on Jan 19, 2026, 3:05 PM UTC (52a6488)">Diff</a>